### PR TITLE
Incorporate st2dev/Hubot

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -17,3 +17,5 @@ mod 'puppetlabs/rabbitmq',           '4.1.0'
 mod 'puppetlabs/vcsrepo',            '1.2.0'
 mod 'stackstorm/st2',                '0.2.0'
 
+mod 'hubot',
+  :git => 'https://github.com/evenup/evenup-hubot'

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ hubot::dependencies:
 Refer to https://github.com/github/hubot/blob/master/docs/adapters.md for additional information about
 Hubot Adapters
 
+Hubot by default is installed at `/opt/hubot`
+
 ### Development Directories
 In the `st2dev` environment, the image makes no attempt to download code for you. Instead, it is
 assumed that most development will be happening on the host machine, and as such you will need to grab

--- a/STACKS.md
+++ b/STACKS.md
@@ -1,0 +1,132 @@
+# Stacks
+
+Underpinning Vagrant is something referred to as Vagrant Stacks. This pattern is another attempt by the
+pattern used in `vagrant-stroller`. In a nutshell, a user should be able to compose entire infrastructure
+stacks quickly and easily with Vagrant, all using potentially different options.
+
+To accomplish this, Vagrant has been extended to read from a `stack` file. A `stack` file is simply
+a YAML file defining what a given infrastructure stack looks like. You can add as many stacks
+as you would like, and switch between them with minimal problems.
+
+An example Vagrant Stack looks like:
+```yaml
+---
+# Defaults can be defined and reused with YAML anchors
+defaults: &defaults
+  domain: stackstorm.net
+  memory: 2048
+  cpus: 1
+  box: puppetlabs/ubuntu-14.04-64-puppet
+# Define as many hosts as you would like. Deep merged in!
+st2server:
+  <<: *defaults  # Take advantage of YAML anchors and inherit
+  hostname: st2server
+  # Any number of facts available to the server can be set here
+  puppet:
+    facts: # Apply facts to the guest OS
+      role: st2server
+  mounts:
+    # Mounts can be in a temp directory
+    - /opt/stackstorm
+    # Or with an absolute path
+    - "/opt/st2web:/tmp/st2web"
+  # Any number of private networks can be defined
+  private_networks:
+    - 10.20.30.2
+```
+
+To switch between a stack, simply change the Environment variable `stack` to something else. This
+can be done at runtime...
+
+```
+stack=cicd vagrant status
+```
+
+... exported for a session ...
+
+```
+# All subsequent actions for the shell session will be this stack
+export stack=cicd
+vagrant status
+```
+
+... or set it up to stay configured indefinetely. This is done via the `dotenv` gem. Simply edit
+the file `.env` in the top-level of this project, and add the line `stack=cicd` and you're done!
+
+See more examples in the `stacks` directory at the top-level of this project.
+
+### Supported Vagrant Objects
+
+* Hostname [`hostname`]
+* Domain [`domain`]
+* Memory [`memory`]
+* Private Networks [`private_networks`]
+* Box name [`box`]
+* Box URL [`box_url`]
+* Puppet Facts [`puppet/facts`]
+* Mounts [`mounts`]
+
+### Digital Ocean Provisioning
+
+In addition to having constructs to manage a `virtualbox` or `vmware_desktop` image, Vagrant Stacks
+also supports using DO as a provisioner. To do this, you must set the following environment variables:
+
+* `DO_SSH_KEY_PATH` - Path to SSH key used to log into servers
+* `DO_TOKEN` - Digital Ocean Token used to provision servers
+
+Then, in a Vagrant Stack, you can specify the following values:
+
+```yaml
+...
+  do:
+    image: '14.04 x64'
+    region: nyc3
+    size: 1gb
+```
+
+Refer to https://www.digitalocean.com/community/tutorials/how-to-use-digitalocean-as-your-provider-in-vagrant-on-an-ubuntu-12-10-vps
+for more information on available options
+
+## Provisioners
+
+Support for many provisioners out-of-the box with the ability to install `st2`, and perform basic
+tasks (install packages, configure users, setup CM downloads, etc) is a goal of this project. To
+that end, you can change also at runtime the provisioner used to provision a server. Set the
+environment variable `provisioner` at runtime, or in the `.env` file as outlined in the overview.
+
+### `puppet-agent`
+
+A script is copied to `/usr/bin/puprun`, which will be used to do branch updates based on upstream `git`,
+and act as the masterless executor.
+
+Puppet can run a series of environments, covered by `git` branching. To deploy a specific branch, simply
+set the environment variable `environment` and off you go!
+
+Example:
+```
+environment=myawesomechange puprun
+```
+
+The node will stay on the `myawesomechange` branch until:
+* The branch is deleted from upstream, where it will automatically revert back to `production`, or...
+* You specify another branch to run as illustrated above
+
+#### Puppet Environments
+
+Vagrant also able to be super flexible. By default, a branch known as `current_working_directory` is
+created and used as the environment for Puppet to run in. This prevents you from having to `git commit`
+and push upstream to make and test local changes.
+
+Vagrant has the ability to mock out different nodes, as well as different environments. Simply use the
+`hostname` and `environment` variables as appropriate.
+
+Vagrant also has the ability to dynamically switch out Vagrant Baseboxes. Use the `box` environment
+variable to change it up. (More details can be found inside the `Vagrantfile`)
+
+Example:
+```
+hostname=ops001 box=fedora vagrant up
+```
+
+The node will remain named `ops001.stackstorm.net` and running on Fedora until it is destroyed
+

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -12,3 +12,4 @@
   - "osfamily/%{::osfamily}"
   - "datacenter/%{::datacenter}"
   - common
+  - workbench

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -4,3 +4,4 @@ classes:
 
 st2::version: 0.8.2
 st2::mistral_git_branch: st2-0.8.1
+

--- a/hieradata/role/st2dev.yaml
+++ b/hieradata/role/st2dev.yaml
@@ -1,0 +1,5 @@
+---
+classes:
+  - 'role::st2dev'
+
+nodejs::proxy: false

--- a/hieradata/role/st2express.yaml
+++ b/hieradata/role/st2express.yaml
@@ -1,3 +1,5 @@
 ---
 classes:
   - 'role::st2express'
+
+npm::proxy: false

--- a/hieradata/workbench.yaml
+++ b/hieradata/workbench.yaml
@@ -2,12 +2,17 @@
 ## Place any user-configurable settings here.
 
 ## Hubot Configuration
-# hubot::adapter: slack
+hubot::adapter: irc
 # hubot::build_deps:
-#  - libxml2-devel
-#  - gcc-c++
-# hubot::env_export:
-#  HUBOT_LOG_LEVEL: DEBUG
-# hubot::dependencies:
-#  hubot: ">= 2.6.0 < 3.0.0"
-#  "hubot-scripts": ">= 2.5.0 < 3.0.0"
+#   - libxml2-devel
+#   - "gcc-c++"
+hubot::env_export:
+  HUBOT_LOG_LEVEL: DEBUG
+  HUBOT_IRC_SERVER: "irc.freenode.net"
+  HUBOT_IRC_ROOMS: "#stackstorm"
+  HUBOT_IRC_NICK: "hubot-stanley"
+  HUBOT_IRC_UNFLOOD: true
+hubot::dependencies:
+  hubot: ">= 2.6.0 < 3.0.0"
+  "hubot-scripts": ">= 2.5.0 < 3.0.0"
+  "hubot-irc": ">= 0.2.7"

--- a/hieradata/workbench.yaml
+++ b/hieradata/workbench.yaml
@@ -1,0 +1,13 @@
+### User configurable settings
+## Place any user-configurable settings here.
+
+## Hubot Configuration
+# hubot::adapter: slack
+# hubot::build_deps:
+#  - libxml2-devel
+#  - gcc-c++
+# hubot::env_export:
+#  HUBOT_LOG_LEVEL: DEBUG
+# hubot::dependencies:
+#  hubot: ">= 2.6.0 < 3.0.0"
+#  "hubot-scripts": ">= 2.5.0 < 3.0.0"

--- a/modules/profile/manifests/hubot.pp
+++ b/modules/profile/manifests/hubot.pp
@@ -1,0 +1,16 @@
+class profile::hubot {
+  include ::hubot
+  package { 'npm':
+    ensure => present,
+  }
+
+  file { '/usr/bin/node':
+    ensure => symlink,
+    target => '/usr/bin/nodejs',
+    require => Class['nodejs'],
+  }
+
+  Exec<| title == 'Hubot init' |> {
+    path => '/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin',
+  }
+}

--- a/modules/profile/manifests/st2_dependencies.pp
+++ b/modules/profile/manifests/st2_dependencies.pp
@@ -1,0 +1,8 @@
+class profile::st2_dependencies {
+  include ::st2::profile::mongodb
+  include ::st2::profile::python
+  include ::st2::profile::rabbitmq
+  class { '::st2::profile::mistral':
+    manage_mysql => true,
+  }
+}

--- a/modules/role/manifests/st2dev.pp
+++ b/modules/role/manifests/st2dev.pp
@@ -1,0 +1,4 @@
+class role::st2dev {
+  include ::profile::st2_dependencies
+  include ::profile::hubot
+}

--- a/modules/role/manifests/st2express.pp
+++ b/modules/role/manifests/st2express.pp
@@ -1,3 +1,4 @@
 class role::st2express {
   include ::profile::st2server
+  include ::profile::hubot
 }

--- a/stacks/st2.yaml
+++ b/stacks/st2.yaml
@@ -7,11 +7,14 @@ defaults: &defaults
   box: puppetlabs/ubuntu-14.04-64-puppet
 st2dev:
   <<: *defaults
+  sync_type: nfs
   hostname: st2dev
   # Any number of facts available to the server can be set here
   puppet:
     facts:
       role: st2dev
+  mounts:
+    - "/mnt/st2:/Users/jfryman/stackstorm/st2"
 st2express:
   <<: *defaults
   hostname: st2express


### PR DESCRIPTION
Several changes in this commit to account for finishing st2dev and
adding Hubot support to both `st2express` and `st2dev`
- Moved `sync_type` attribute to stacks
- Added user-specific Hiera configuration (workbench.yaml).
- Adds Hubot profile
- Adds st2_dependencies profile

Also dramatically updates the README, splitting up unnecessary bits to STACKS.md
