### PR TITLE
Adding ability to add arbitrary users to environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,23 @@ st2dev:
 ```
 
 NOTE: You may be asked for permission to make modifications to the Host's `/etc/exports` file.
+
+### Adding Users
+By default, the `stanley` user is added to both the `st2express` and `st2dev` roles. However, there
+may exist times where you want to add a local user to the box. To do this, simply add an entry to
+`hieradata/workroom.yaml` under the `users` key.
+
+For example, to add a new user, simply:
+
+```
+---
+users:
+  manas:
+    uid: 700
+    gid: 700
+    sshkey: XXXXXX
+    sshkeytype: ssh-rsa
+    shell: /bin/bash
+    admin: true
+```
+```

--- a/modules/profile/manifests/st2_dependencies.pp
+++ b/modules/profile/manifests/st2_dependencies.pp
@@ -1,4 +1,5 @@
 class profile::st2_dependencies {
+  include ::st2::stanley
   include ::st2::profile::mongodb
   include ::st2::profile::python
   include ::st2::profile::rabbitmq

--- a/modules/profile/manifests/users.pp
+++ b/modules/profile/manifests/users.pp
@@ -1,0 +1,4 @@
+class profile::users {
+  $users = hiera_hash('users')
+  create_resources('users', $users)
+}

--- a/modules/role/manifests/st2dev.pp
+++ b/modules/role/manifests/st2dev.pp
@@ -1,4 +1,5 @@
 class role::st2dev {
   include ::profile::st2_dependencies
   include ::profile::hubot
+  include ::profile::users
 }

--- a/modules/role/manifests/st2express.pp
+++ b/modules/role/manifests/st2express.pp
@@ -1,4 +1,5 @@
 class role::st2express {
   include ::profile::st2server
   include ::profile::hubot
+  include ::profile::users
 }

--- a/modules/users/manifests/init.pp
+++ b/modules/users/manifests/init.pp
@@ -1,0 +1,68 @@
+define users(
+  $ensure      = present,
+  $username    = $name,
+  $home        = "/home/${name}",
+  $sshkey      = undef,
+  $sshkeytype  = 'ssh-rsa',
+  $shell       = '/bin/bash',
+  $admin       = false,
+  $uid,
+  $gid,
+) {
+
+  if $ensure == present {
+    user{ $username:
+      ensure      => $ensure,
+      uid         => $uid,
+      gid         => $gid,
+      shell       => $shell,
+      managehome  => true,
+      require => Group[$username]
+    }
+
+    group{ $username:
+      ensure => $ensure,
+      gid    => $gid
+    }
+
+    file{ $home:
+      ensure      => 'directory',
+      owner       => $username,
+      group       => $username,
+      mode        => '0700',
+      require     => User[$username]
+    }
+
+    file{ "${home}/.ssh":
+      ensure  => 'directory',
+      owner   => $username,
+      group   => $username,
+      mode    => '0700',
+      require => File["${home}"]
+    }
+
+    if $sshkey and $sshkeytype {
+      ssh_authorized_key{"${username}-${sshkeytype}-ssh_authorized_key":
+        ensure      => $ensure,
+        user        => $username,
+        type        => $sshkeytype,
+        key         => $sshkey,
+        require   => File["${home}/.ssh"]
+      }
+    }
+  } else {
+    user{ $username:
+      ensure  => absent,
+      require => Service["user@${username}.service"]
+    }
+  }
+
+  if $admin {
+    include ::sudo
+    sudo::conf { "${username}-admin":
+      ensure   => $ensure,
+      priority => 10,
+      content  => "${username}    ALL=(ALL)       NOPASSWD: ALL",
+    }
+  }
+}

--- a/stacks/st2.yaml
+++ b/stacks/st2.yaml
@@ -13,13 +13,10 @@ st2dev:
   puppet:
     facts:
       role: st2dev
-  mounts:
-    - "/mnt/st2:/Users/jfryman/stackstorm/st2"
 st2express:
   <<: *defaults
   hostname: st2express
   puppet:
     facts:
       role: st2express
-  mounts:
-    - "/mnt/st2incubator:/Users/jfryman/stackstorm/st2incubator"
+


### PR DESCRIPTION
This PR adds the ability to specify arbitrary users in Hiera and have them installed/managed in either the `st2dev` or `st2express` environments.
### Adding Users

By default, the `stanley` user is added to both the `st2express` and `st2dev` roles. However, there
may exist times where you want to add a local user to the box. To do this, simply add an entry to
`hieradata/workroom.yaml` under the `users` key.

For example, to add a new user, simply:

```

---
users:
  manas:
    uid: 700
    gid: 700
    sshkey: XXXXXX
    sshkeytype: ssh-rsa
    shell: /bin/bash
    admin: true
```
