### PR TITLE
Fixing bundler error due to lack of ruby development package

### DIFF
--- a/script/bootstrap-ubuntu
+++ b/script/bootstrap-ubuntu
@@ -26,10 +26,8 @@ apt-get -y install \
   puppetdb-terminus=$PUPPETDB_TERMINUS_VER-1puppetlabs1 \
   ruby-bundler
 
-apt-get -y install rubygems || true
-
 gem install bundler deep_merge --no-ri --no-rdoc
 
-apt-get install -y unzip wget ruby git
+apt-get install -y unzip wget ruby ruby-dev git
 
 touch /etc/vagrant-bootstrapped


### PR DESCRIPTION
**Resolution**
Adding in the ruby-dev package to the script/bootstrap-ubuntu script to prevent Ruby bundler from having issues compiling native extensions.

**QA**
- Tested "vagrant up" successfully completes with no major errors

**Previous Behavior**
Vagrant would exit during the provisioning stage with a major error while running bundle.

Note: Using the st2express vagrant server, but this exists on both st2express and st2dev

```
> vagrant up st2express
...
==> st2express: Reading package lists...
==> st2express: Building dependency tree...
==> st2express: Reading state information...
==> st2express: Package rubygems is not available, but is referred to by another package.
==> st2express: This may mean that the package is missing, has been obsoleted, or
==> st2express: is only available from another source
==> st2express: However the following packages replace it:
==> st2express:   ruby
==> st2express: E
==> st2express: :
==> st2express: Package 'rubygems' has no installation candidate
...
==> st2express: Installing rake 10.3.2
==> st2express: Installing CFPropertyList 2.2.8
==> st2express: Gem::Installer::ExtensionBuildError: ERROR: Failed to build gem native extension.
==> st2express:
==> st2express:         /usr/bin/ruby1.9.1 extconf.rb
==> st2express: /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require': cannot load such file -- mkmf (LoadError)
==> st2express:     from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
==> st2express:     from extconf.rb:2:in `<main>'
==> st2express:
==> st2express:
==> st2express: Gem files will remain installed in /opt/puppet/vendor/bundle/ruby/1.9.1/gems/hitimes-1.2.2 for inspection.
==> st2express: Results logged to /opt/puppet/vendor/bundle/ruby/1.9.1/gems/hitimes-1.2.2/ext/hitimes/c/gem_make.out
==> st2express: An error occurred while installing hitimes (1.2.2), and Bundler cannot continue.
==> st2express: Make sure that `gem install hitimes -v '1.2.2'` succeeds before bundling.
==> st2express: bundler: command not found: r10k
==> st2express: Install missing gem executables with `bundle install`
==> st2express: Error: Evaluation Error: Error while evaluating a Function Call, Could not find class ::st2::profile::fullinstall for st2express.stackstorm.net at /opt/puppet/environments/current_working_directory/modules/profile/manifests/st2server.pp:2:3 on node st2express.stackstorm.net
==> st2express: Error: Evaluation Error: Error while evaluating a Function Call, Could not find class ::st2::profile::fullinstall for st2express.stackstorm.net at /opt/puppet/environments/current_working_directory/modules/profile/manifests/st2server.pp:2:3 on node st2express.stackstorm.net
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
...
```

**New Behavior**
Vagrant completes the 'vagrant up' command with no major errors

Note: Using the st2express vagrant server, but this exists on both st2express and st2dev

```
> vagrant up st2express...
No more error about the rubygems package
...
==> st2express: Installing rake 10.3.2
==> st2express: Installing CFPropertyList 2.2.8
==> st2express: Installing hitimes 1.2.2
==> st2express: Installing timers 4.0.1
==> st2express: Installing celluloid 0.16.0
==> st2express: Installing coderay 1.1.0
==> st2express: Installing colored 1.2
==> st2express: Installing cri 2.5.0
==> st2express: Installing deep_merge 1.0.1
==> st2express: Installing diff-lcs 1.2.5
==> st2express: Installing dotenv-deployment 0.0.2
==> st2express: Installing dotenv 0.11.1
==> st2express: Installing facter 2.2.0
==> st2express: Installing multipart-post 1.2.0
==> st2express: Installing faraday 0.8.9
==> st2express: Installing faraday_middleware 0.9.1
==> st2express: Installing multi_json 1.8.4
==> st2express: Installing faraday_middleware-multi_json 0.0.6
==> st2express: Installing ffi 1.9.8
==> st2express: Installing formatador 0.2.5
==> st2express: Installing rb-fsevent 0.9.4
==> st2express: Installing rb-inotify 0.9.5
==> st2express: Installing listen 2.9.0
==> st2express: Installing lumberjack 1.0.9
==> st2express: Installing nenv 0.2.0
==> st2express: Installing shellany 0.0.1
==> st2express: Installing notiffany 0.0.6
==> st2express: Installing method_source 0.8.2
==> st2express: Installing slop 3.6.0
==> st2express: Installing pry 0.10.1
==> st2express: Installing thor 0.19.1
==> st2express: Installing guard 2.12.5
==> st2express: Installing guard-compat 1.2.1
==> st2express: Installing guard-shell 0.7.1
==> st2express: Installing json_pure 1.8.1
==> st2express: Installing hiera 1.3.4
==> st2express: Installing log4r 1.1.10
==> st2express: Installing net-ssh 2.9.1
==> st2express: Installing puppet 3.7.3
==> st2express: Installing puppet-lint 0.3.2
==> st2express: Installing systemu 2.5.2
==> st2express: Installing r10k 1.3.5
==> st2express: Installing rspec-support 3.1.2
==> st2express: Installing rspec-core 3.1.7
==> st2express: Installing rspec-expectations 3.1.2
==> st2express: Installing rspec-mocks 3.1.3
==> st2express: Installing rspec 3.1.0
==> st2express: Installing rspec-puppet 1.0.1
==> st2express: Using bundler 1.9.2
==> st2express: Updating files in vendor/cache
==> st2express: Bundle complete! 12 Gemfile dependencies, 49 gems now installed.
```
