### PR TITLE
Repairing Fedora/RedHat errors

### DIFF
--- a/modules/profile/manifests/hubot.pp
+++ b/modules/profile/manifests/hubot.pp
@@ -1,7 +1,10 @@
 class profile::hubot {
   include ::hubot
-  package { 'npm':
-    ensure => present,
+
+  if $::osfamily == 'Debian' {
+    package { 'npm':
+      ensure => present,
+    }
   }
 
   file { '/usr/bin/node':

--- a/script/bootstrap-redhat
+++ b/script/bootstrap-redhat
@@ -42,7 +42,7 @@ yum install -y \
   puppet-$PUPPET_VER \
   puppetdb-terminus-$PUPPETDB_TERMINUS_VER \
 
-yum install -y unzip wget ruby git
+yum install -y unzip wget ruby git ruby-devel
 gem install bundler deep_merge --no-ri --no-rdoc
 
 touch /etc/vagrant-bootstrapped

--- a/script/puppet-apply
+++ b/script/puppet-apply
@@ -4,6 +4,8 @@ PROJECT_ROOT=/opt/puppet
 NODE=$(hostname -s);
 BUNDLER_ARGS=""
 
+export PATH=/usr/local/bin:$PATH
+
 cd $PROJECT_ROOT
 
 ### Setup the puppet directory


### PR DESCRIPTION
This commit adds a few fixes that prevented Fedora machines from
completing vagrant bootstrap and compiling a puppet catalog. Mostly
environmental settings, but the list of changes includes:
- Only install npm package on Debian machines
- Ensure ruby development libraries are installed
- Update the path during puppet run to find `bundler`
