### PR TITLE
Add support for Hubot Prefxes

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -22,4 +22,5 @@ mod 'counsyl/packer',                '0.9.14'
 mod 'counsyl/sys',                   '0.9.17'
 
 mod 'hubot',
-  :git => 'https://github.com/evenup/evenup-hubot'
+  :git => 'https://github.com/jfryman/evenup-hubot',
+  :ref => 'alias-support'

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ IRC room, for example, simply set the following values in `hieradata/workroom.ya
 
 ```
 hubot::adapter: irc
+hubot::chat_alias: !
 hubot::env_export:
   HUBOT_LOG_LEVEL: DEBUG
   HUBOT_IRC_SERVER: "irc.freenode.net"


### PR DESCRIPTION
This commit adds support for Hubot to have an alias associated with
its usage. This allows for easier typing of commands in chat without
having to address the full name of the bot for each command. By
default this alias will be set to '/', and can be changed by
setting the `hubot::chat_alias` attribute in Hiera

This commit changes the version of Hubot module to a fork until
https://github.com/evenup/evenup-hubot/pull/18 is merged upstream
