### PR TITLE
Enable custom hubot installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,18 @@ hubot::dependencies:
   "hubot-irc": ">= 0.2.7"
 ```
 
+Installing an existing install of Hubot is equally easy. Simply replace the `hubot::dependencies` key
+with values for `hubot::git_soucre` and `hubot::ssh_privatekey`. For exapmle, in `hieradata/workroom.yaml`:
+
+```
+hubot::adapter: slack
+hubot::chat_alias: "!"
+hubot::git_source: "git@github.com:StackStorm/hubot-stanley.git"
+hubot::ssh_privatekey: "-----BEGIN RSA PRIVATE KEY-----YYY-----END RSA PRIVATE KEY-----"
+hubot::env_export:
+  HUBOT_SLACK_TOKEN: "XXX"
+```
+
 Refer to https://github.com/github/hubot/blob/master/docs/adapters.md for additional information about
 Hubot Adapters
 

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -2,6 +2,4 @@
 classes:
   - 'puppet::masterless'
 
-st2::version: 0.8.3
-st2::mistral_git_branch: st2-0.8.1
 

--- a/hieradata/workroom.yaml.example
+++ b/hieradata/workroom.yaml.example
@@ -1,6 +1,10 @@
 ### User configurable settings
 ## Place any user-configurable settings here.
 
+## StackStorm Versions
+# st2::version: 0.8.3
+# st2::mistral_git_branch: st2-0.8.1
+
 ## Stanley User Configuration
 # st2::stanley::ssh_public_key: XXXXXX
 # st2::stanley::ssh_key_type: ssh-rsa

--- a/modules/profile/templates/hubot/upstart_init.erb
+++ b/modules/profile/templates/hubot/upstart_init.erb
@@ -1,0 +1,18 @@
+description "<%= @bot_name %>"
+author "Estee Tew"
+
+start on (filesystem and net-device-up IFACE=lo)
+stop on runlevel [!2345]
+
+setuid hubot
+setgid hubot
+
+<%- @env_vars.each do |k,v| -%>
+env <%= k %>=<%= v %>
+<%- end -%>
+
+chdir <%= @hubot_home %>
+
+script
+  bin/hubot --adapter slack --name <%= @bot_name %> --alias <%= @chat_alias %> 2>&1 | logger -t hubot
+end script


### PR DESCRIPTION
This commit allows the st2workroom to use a hubot install that has
been version controlled as the source for deployment.

Installing an existing install of Hubot is equally easy. Simply
replace the `hubot::dependencies` key with values for `hubot::git_source`
and `hubot::ssh_privatekey`. For exapmle, in `hieradata/workroom.yaml`:

```
hubot::adapter: slack
hubot::chat_alias: "!"
hubot::git_source: "git@github.com:StackStorm/hubot-stanley.git"
hubot::ssh_privatekey: "-----BEGIN RSA PRIVATE KEY-----YYY-----END RSA PRIVATE KEY-----"
hubot::env_export:
  HUBOT_SLACK_TOKEN: "XXX"
```
