### PR TITLE
adding private_networks to default st2 stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ To SSH into the machine, simply type the following command:
   vagrant ssh st2express
 ```
 
+NOTE: In the event you receive an error related to IP conflict, Edit the `private_neworks` address in `stacks/st2.yaml`, and adjust the third octet to a non-conflicting value. For example:
+
+```
+st2express:
+  ...
+    private_networks:
+        - 172.168.50.10
+```
+
+The third octet is now set to `50` as opposed to `100`, the default value. Once changed, reload vagrant with the `vagrant reload` command.
+
+
 ### st2dev
 
 st2dev is used as a clean room environment to develop StackStorm against. This machine downloads all
@@ -191,3 +203,19 @@ users:
     shell: /bin/bash
     admin: true
 ```
+
+## Known Issues
+
+Unfortunately, as seamless as we attemt to make this project, there are a few issues that we cannot code around. But, they're easy enough to fix, and your solution might be listed below.
+
+### IP Conflicts
+In the event you receive an error related to IP conflict, Edit the `private_neworks` address in `stacks/st2.yaml`, and adjust the third octet to a non-conflicting value. For example:
+
+```
+st2express:
+  ...
+    private_networks:
+        - 172.168.50.10
+```
+
+The third octet is now set to `50` as opposed to `100`, the default value. Once changed, reload vagrant with the `vagrant reload` command.

--- a/stacks/st2.yaml
+++ b/stacks/st2.yaml
@@ -12,16 +12,21 @@ st2dev:
   puppet:
     facts:
       role: st2dev
+  private_networks:
+    - 172.168.60.10
 st2express:
   <<: *defaults
   hostname: st2express
   puppet:
     facts:
       role: st2express
+  private_networks:
+    - 172.168.100.11
 st2factory:
   <<: *defaults
   hostname: st2factory
   puppet:
     facts:
       role: st2factory
-
+  private_networks:
+    - 172.168.50.12


### PR DESCRIPTION
This PR updates the configuration of the default stack to include a private address. This is to address mDNS not working with the Virtualbox provider, which does not pass through the shared NAT.

Fixes https://github.com/StackStorm/st2workroom/issues/16
