### PR TITLE
Move Hubot HTTP port to 8081

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -7,7 +7,7 @@ st2::packs:
     ensure: present
     repo_url: https://github.com/StackStorm/st2incubator.git
     config:
-      endpoint: "http://localhost:8080"
+      endpoint: "http://localhost:8081"
   deploy:
     ensure: present
     repo_url: https://github.com/StackStorm/st2incubator.git

--- a/modules/profile/manifests/hubot.pp
+++ b/modules/profile/manifests/hubot.pp
@@ -22,10 +22,15 @@ class profile::hubot(
 
   # Accomidate a custom hubot install vs default
   if $::hubot::git_source {
-    $env_vars   = hiera_hash('hubot::env_export', {})
-    $hubot_home = "${::hubot::root_dir}/${bot_name}"
-    $adapter    = $::hubot::adapter
-    $chat_alias = $::hubot::chat_alias
+    $hiera_env_vars = hiera_hash('hubot::env_export', {})
+    $stackstorm_env_vars = {
+      'EXPRESS_PORT' => '8081',
+    }
+    $env_vars = merge($hiera_env_vars, $stackstorm_env_vars)
+
+    $hubot_home     = "${::hubot::root_dir}/${bot_name}"
+    $adapter        = $::hubot::adapter
+    $chat_alias     = $::hubot::chat_alias
 
     file { '/etc/init/hubot.conf':
       ensure  => file,

--- a/script/puppet-apply
+++ b/script/puppet-apply
@@ -104,6 +104,11 @@ if [ ! -d $PROJECT_ROOT/graphs/${NODE} ]; then
   mkdir -p $PROJECT_ROOT/graphs/${NODE}
 fi
 
+## Make sure apt is up-to-date if a Debian box
+if [ -e /usr/bin/apt-get ]; then
+  apt-get update
+fi
+
 puppet apply $PUPPET_DEBUG_ARGS --verbose --environment $environment \
   --config $PROJECT_ROOT/puppet.conf \
   --graph --graphdir $PROJECT_ROOT/graphs/${NODE} \


### PR DESCRIPTION
This PR moves the default HTTP Express port to `8081`. This is to account for changes to the `st2web` that now lives on `8080`, thus avoiding port conflicts.

/cc https://github.com/StackStorm/st2/pull/1362
