### PR TITLE
Remove SSH Key instructions for Hubot wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,15 +135,17 @@ hubot::dependencies:
 ```
 
 Installing an existing install of Hubot is equally easy. Simply replace the `hubot::dependencies` key
-with values for `hubot::git_soucre` and `hubot::ssh_privatekey`. For exapmle, in `hieradata/workroom.yaml`:
+with a value for `hubot::git_soucre`. For exapmle, in `hieradata/workroom.yaml`:
 
 ```
+# hieradata/workroom.yaml
+---
 hubot::adapter: slack
 hubot::chat_alias: "!"
-hubot::git_source: "git@github.com:StackStorm/hubot-stanley.git"
-hubot::ssh_privatekey: "-----BEGIN RSA PRIVATE KEY-----YYY-----END RSA PRIVATE KEY-----"
 hubot::env_export:
-  HUBOT_SLACK_TOKEN: "XXX"
+  HUBOT_SLACK_TOKEN: "xoxb-XXXX"
+  HUBOT_LOG_LEVEL: debug
+hubot::git_source: "https://github.com/StackStorm/hubot-stanley.git"
 ```
 
 Refer to https://github.com/github/hubot/blob/master/docs/adapters.md for additional information about


### PR DESCRIPTION
Hubot ChatOps plugin is now OSS. This PR removes the necessity to define SSH keys to download a private repository.

Found by @dzimine 
