### PR TITLE
Move hubot pack to st2contrib

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -7,7 +7,6 @@ st2::auth: false
 st2::packs:
   hubot:
     ensure: present
-    repo_url: https://github.com/StackStorm/st2incubator.git
     config:
       endpoint: "http://localhost:8081"
   deploy:


### PR DESCRIPTION
This PR updates st2workroom to pull hubot pack from `st2contrib` as opposed to `st2incubator`.
