### PR TITLE
Remove automatic mount

### DIFF
--- a/stacks/st2.yaml
+++ b/stacks/st2.yaml
@@ -24,8 +24,6 @@ st2express:
       role: st2express
   private_networks:
     - 172.168.50.11
-  mounts:
-    - '/opt/stackstorm/packs:artifacts/packs'
 st2factory:
   <<: *defaults
   hostname: st2factory


### PR DESCRIPTION
Removes the automatic mount, as packs are pre-packaged into the st2express image.

/cc @lakshmi-kannan 
