### PR TITLE
Adding default playbook

### DIFF
--- a/stacks/st2.yaml
+++ b/stacks/st2.yaml
@@ -19,6 +19,8 @@ st2express:
   <<: *defaults
   hostname: st2express
   box: stackstorm/st2express
+  ansible:
+    playbook: playbooks/st2express.yaml
   puppet:
     facts:
       role: st2express


### PR DESCRIPTION
Pulling from https://github.com/StackStorm/st2workroom/pull/27/files#diff-ae88a52b13b7fff7115ff687426104fcR20, this commit adds some metadata necessary to bootstrap ansible in the workroom for those using the ansible provisioner.
