### PR TITLE
Autostart uwsgi processes on boot

### DIFF
--- a/modules/adapter/templates/st2_uwsgi_init/init.conf.erb
+++ b/modules/adapter/templates/st2_uwsgi_init/init.conf.erb
@@ -8,8 +8,8 @@
 description     "StackStorm <%= @_subsystem %> uWSGI Daemon"
 author          "StackStorm Engineering <opsadmin@stackstorm.com>"
 
-start on starting <%= @_subsystem %>
-stop on stopping <%= @_subsystem %>
+start on runlevel [2345]
+stop on runlevel [016]
 
 respawn
 respawn limit 2 5


### PR DESCRIPTION
This PR reconfigures the init script template for `uwsgi` daemons (in scope: `st2auth`, `st2installer`, and `mistral`). This sets them to auto-start on boot, which was not previously happening before.

Reported by @dzimine in #57 
