### PR TITLE
Fixing workroom loading existing workroom.yaml

### DIFF
--- a/modules/profile/manifests/infrastructure.pp
+++ b/modules/profile/manifests/infrastructure.pp
@@ -22,9 +22,22 @@ class profile::infrastructure {
     command => "/bin/hostname -F /etc/hostname",
     unless  => "/usr/bin/test `hostname` = `/bin/cat /etc/hostname`",
   }
+
+  # Manage the entire /etc/hosts
+  # This is needed to ensure no dangling left-over host entries.
+  resources { 'host':
+    purge => true,
+  }
+  host { 'default v4 localhost':
+    ensure       => present,
+    name         => 'localhost.localdomain',
+    ip           => '127.0.0.1',
+    host_aliases => 'localhost',
+  }
   host { 'default hostname v4':
-    ensure        => present,
-    name          => $_hostname,
-    ip            => $_host_ip,
+    ensure       => present,
+    name         => $_hostname,
+    ip           => $_host_ip,
+    host_aliases => $::hostname,
   }
 }

--- a/modules/profile/manifests/st2server.pp
+++ b/modules/profile/manifests/st2server.pp
@@ -175,10 +175,11 @@ class profile::st2server {
 
   anchor { 'st2::pre_reqs': }
   -> class { '::st2::profile::client':
-    username => $_root_cli_username,
-    password => $_root_cli_password,
-    api_url  => $_api_url,
-    auth_url => $_auth_url,
+    username    => $_root_cli_username,
+    password    => $_root_cli_password,
+    api_url     => $_api_url,
+    auth_url    => $_auth_url,
+    cache_token => false,
   }
   -> class { '::st2::profile::server':
     auth                   => true,

--- a/script/tasks/environment.rake
+++ b/script/tasks/environment.rake
@@ -18,7 +18,7 @@ namespace :environments do
 
     # Unless specified, only deploy the requested branch
     branch.eql?('all') ? deploy = branches : deploy = branch
-    
+
     Rake::Task['environments:cleanup'].invoke(envs_dir, branches)
     Rake::Task['environments:setup'].invoke(envs_dir, repo_dir, deploy)
     Rake::Task['environments:symlink'].invoke(envs_dir)
@@ -79,7 +79,7 @@ namespace :environments do
       FileUtils.rm_rf "#{env_checkout}.old" if File.directory? "#{env_checkout}.old"
     end
   end
-  
+
   task :symlink, :environments_dir do |_, args|
     environments_dir = args[:environments_dir]
 

--- a/script/tasks/helpers.rake
+++ b/script/tasks/helpers.rake
@@ -24,6 +24,6 @@ def ln_nfs(source, dest)
 end
 
 def log(message)
-  timestr = Time.now.strftime("%M:%M:%S")
+  timestr = Time.now.strftime("%H:%M:%S")
   puts "[#{timestr}] #{message}"
 end


### PR DESCRIPTION
The last little bit with this round of the workroom.

This PR fixes up the workroom to properly parse an existing `workroom.yaml`. This is good if you end up saving the answers file from the installer, and keeping it as the `workroom.yaml` file to allow rapid booting to your saved environment.

This previously did not work because the installation only worked properly on first pass. This updates some of the resources to fix the renaming of hosts, which is what caused RabbitMQ hangups in the first place. Also prevents token caching on the root user, hopefully alleviating a good deal of issues.
