### PR TITLE
Vmware fixes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -197,7 +197,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |vagrant|
       ## Bootstrap using different provisioners.
       case PROVISIONER
       when 'puppet-apply' then
-        n.vm.synced_folder '.', '/opt/puppet', type: @synced_folder_type
+        n.vm.synced_folder '.', '/opt/puppet', type: config['sync_type']
         n.vm.provision 'shell', inline: '/opt/puppet/script/bootstrap-linux'
         n.vm.provision 'shell', inline: <<-EOF
           # Skips the `git pull` step, since you're working out of it directly

--- a/packer/script/ubuntu/base.sh
+++ b/packer/script/ubuntu/base.sh
@@ -12,7 +12,6 @@ sed -i -e 's/%sudo  ALL=(ALL:ALL) ALL/%sudo  ALL=NOPASSWD:ALL/g' /etc/sudoers
 
 echo "UseDNS no" >> /etc/ssh/sshd_config
 
-
 # Install Puppet Source
 if [ -f /etc/apt/sources.list.d/puppetlabs.list ]; then
   rm /etc/apt/sources.list.d/puppetlabs.list
@@ -24,7 +23,6 @@ if [ ! -f /etc/apt/sources.list.d/puppetlabs-pc1.list ]; then
 fi
 
 apt-get update
-apt-get -y upgrade
 apt-get -y install linux-headers-$(uname -r) build-essential
 apt-get -y install unzip wget ruby ruby-dev git
 apt-get -y install puppet-agent ruby-bundler unzip wget ruby ruby-dev git


### PR DESCRIPTION
This PR fixes a few bugs found when using the `vmware_desktop` provider in Vagrant.
- `/opt/puppet` now respects the `sync_type` parameter for syncing during provisioning
- The base image does not update fully, since the installer does a full update before packaging
