### PR TITLE
Do not error after convergence

### DIFF
--- a/modules/deprecate/manifests/os_mongodb_0001.pp
+++ b/modules/deprecate/manifests/os_mongodb_0001.pp
@@ -30,7 +30,7 @@ class deprecate::os_mongodb_0001(
       $_converged = true
       $_current_stage = 'uninstalled'
     }
-    default: { fail("[deprecate::os_mongodb_0001]: Unknown stage: ${_stage}. Please adjust and retry") }
+    default: { }
   }
 
   if $enforce {

--- a/modules/deprecate/manifests/os_rabbitmq_0001.pp
+++ b/modules/deprecate/manifests/os_rabbitmq_0001.pp
@@ -24,7 +24,7 @@ class deprecate::os_rabbitmq_0001(
       $_package_ensure = 'absent'
       $_converged = true
     }
-    default: { fail("[deprecate::os_rabbitmq_0001]: Unknown stage: ${_stage}. Please adjust and retry") }
+    default: { }
   }
 
   if $enforce {
@@ -35,7 +35,7 @@ class deprecate::os_rabbitmq_0001(
       package_ensure => $_package_ensure,
     }
 
-    # Set the breadcrumb for the next run.
+# Set the breadcrumb for the next run.
     file { '/etc/facter/facts.d/deprecate_os_rabbitmq_0001_stage.txt':
       ensure  => file,
       owner   => 'root',


### PR DESCRIPTION
This PR removes the `fail` step after convergence of recently added deprecation errors.

Fixes:

```
Error: Evaluation Error: Error while evaluating a Function Call, [deprecate::os_rabbitmq_0001]: Unknown stage: removed. Please adjust and retry at /opt/puppet/environments/production/modules/deprecate/manifests/os_rabbitmq_0001.pp:27:16 on node ss.skynerv.com
```
