### PR TITLE
Stop mongo/rabbit packages from reinstalling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## In Development
+* Fix mongodb/rabbitmq OS packages from reinstalling/restarting in a loop (*bugfix*)
+
 ## v0.2.1 / Aug 29, 2015
 * Remove unnecessary `fail` on deprecation convergence logic. (*bugfix*)
 * Keep existing `sudoers` entries on host during installation (*bugfix*)

--- a/modules/deprecate/manifests/os_mongodb_0001.pp
+++ b/modules/deprecate/manifests/os_mongodb_0001.pp
@@ -29,6 +29,10 @@ class deprecate::os_mongodb_0001(
       $_next_stage = 'uninstalled'
     }
     default: {
+      $_service_ensure = 'stopped'
+      $_service_enable = 'false'
+      $_package_ensure = 'absent'
+
       $_next_stage = undef
     }
   }

--- a/modules/deprecate/manifests/os_rabbitmq_0001.pp
+++ b/modules/deprecate/manifests/os_rabbitmq_0001.pp
@@ -27,6 +27,10 @@ class deprecate::os_rabbitmq_0001(
       $_next_stage = 'complete'
     }
     default: {
+      $_service_ensure = undef
+      $_service_manage = false
+      $_package_ensure = 'absent'
+
       $_next_stage = undef
     }
   }


### PR DESCRIPTION
The deprecation module logic currently executes a loop, stopping the service, uninstalling the package, reinstalling the service, and then starting again. The logic to step through installation is now configured to stop and rest at the final state as opposed to restarting again.
