### PR TITLE
"Unable to connect" when hostname is not FQDN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## In Development
 * Fix mongodb/rabbitmq OS packages from reinstalling/restarting in a loop (*bugfix*)
+* Fix connection errors when host machine does not have FQDN defined (*bugfix*)
 
 ## v0.2.1 / Aug 29, 2015
 * Remove unnecessary `fail` on deprecation convergence logic. (*bugfix*)

--- a/modules/profile/manifests/infrastructure.pp
+++ b/modules/profile/manifests/infrastructure.pp
@@ -1,5 +1,5 @@
 class profile::infrastructure {
-  $_hostname = hiera('system::hostname', $::fqdn)
+  $_hostname = hiera('system::hostname', $::hostname)
   $_host_ip = hiera('system::ipaddress', $::ipaddress)
   $_packages = hiera('system::packages', [])
   include ::ntp
@@ -38,6 +38,6 @@ class profile::infrastructure {
     ensure       => present,
     name         => $_hostname,
     ip           => $_host_ip,
-    host_aliases => $::hostname,
+    host_aliases => $::fqdn,
   }
 }

--- a/modules/profile/manifests/st2server.pp
+++ b/modules/profile/manifests/st2server.pp
@@ -9,7 +9,7 @@ class profile::st2server {
   $_installed = hiera('st2::installer_run', false)
   $_user_ssl_cert = hiera('st2::ssl_public_key', undef)
   $_user_ssl_key = hiera('st2::ssl_private_key', undef)
-  $_hostname = hiera('system::hostname', $::fqdn)
+  $_hostname = hiera('system::hostname', $::hostname)
   $_host_ip = hiera('system::ipaddress', $::ipaddress_eth0)
   $_installer_workroom_mode = hiera('st2::installer_workroom_mode', '0660')
   $_st2auth_uwsgi_threads = hiera('st2::auth_uwsgi_threads', 10)


### PR DESCRIPTION
We received reports of users not getting the ST2 OK. It was discovered if the hostname when the installer is first provisioned is not a Fully Qualified Domain Name, the SSL certificate generated would not match the connection string and be rejected.

This change allows both FQDN and Hostname values for the hostname and allow successful provision.
