### PR TITLE
Restart StackStorm services on Hostname change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In Development
 * Fix mongodb/rabbitmq OS packages from reinstalling/restarting in a loop (*bugfix*)
 * Fix connection errors when host machine does not have FQDN defined (*bugfix*)
+* Fix StackStorm service authentication failure on host rename (*bugfix*)
 
 ## v0.2.1 / Aug 29, 2015
 * Remove unnecessary `fail` on deprecation convergence logic. (*bugfix*)

--- a/modules/profile/manifests/st2server.pp
+++ b/modules/profile/manifests/st2server.pp
@@ -716,17 +716,29 @@ class profile::st2server {
 
   ## Because authentication is now being passed via Nginx, we need to make sure that
   ## the service for nginx is up and running before responding to any CLI requests
-  Service['nginx'] -> Exec<| tag == 'st2::kv' |>
-  Service['nginx'] -> Exec<| tag == 'st2::pack' |>
+  Service['nginx'] -> Exec['restart st2'] -> Exec<| tag == 'st2::kv' |>
+  Service['nginx'] -> Exec['restart st2'] -> Exec<| tag == 'st2::pack' |>
 
   ## First Run
   # Here lies a few things that need to be done only on the first run. Make sure at some point
   # that we converge all of the content on the machine. This is needed to reduce shipping size
   # of the final asset, so databases are sent un-populated.
+
   exec { 'register all st2 content':
     command => 'st2ctl reload --register-all',
     unless  => 'st2 action list | grep packs.install',
     path    => '/usr/bin:/usr/sbin:/bin:/sbin',
     require => Service['nginx'],
+    notify  => Exec['restart st2'],
+  }
+  exec { 'restart st2':
+    command     => 'st2ctl restart',
+    path        => '/usr/sbin:/usr/bin:/sbin:/bin',
+    refreshonly => true,
+  }
+
+  # Reloads also need to happen anytime the hostname changes
+  Host<| name == $_hostname |> {
+    notify => Exec['restart st2'],
   }
 }


### PR DESCRIPTION
This PR tells StackStorm services to restart in the event that a host is renamed.
