### PR TITLE
Remove old deprecation classes

### DIFF
--- a/modules/profile/manifests/mongodb.pp
+++ b/modules/profile/manifests/mongodb.pp
@@ -1,6 +1,4 @@
 class profile::mongodb {
-  include ::deprecate::os_mongodb_0001
-
   include ::docker
   $_version = hiera('mongodb::version', '2.4.14')
 

--- a/modules/profile/manifests/rabbitmq.pp
+++ b/modules/profile/manifests/rabbitmq.pp
@@ -1,7 +1,5 @@
 class profile::rabbitmq {
   $_version = hiera('rabbitmq::version', '3.5.4')
-  include ::deprecate::os_rabbitmq_0001
-
   include ::docker
 
   docker::image { 'rabbitmq':


### PR DESCRIPTION
This class was a temporary transition class for older installations to ensure that they got moved to Docker.  Not needed for new installs anymore.
