### PR TITLE
Ensure CORS headers are everywhere

### DIFF
--- a/modules/profile/manifests/st2server.pp
+++ b/modules/profile/manifests/st2server.pp
@@ -561,10 +561,14 @@ class profile::st2server {
     ssl_ciphers          => $_cipher_list,
     server_name          => $_server_names,
     uwsgi                => "unix://${_st2auth_socket}",
+    add_header           => [
+      'Access-Control-Allow-Origin *',
+    ],
     proxy_set_header     => [
       'Host $host',
       'X-Real-IP $remote_addr',
       'X-Forwarded-For $proxy_add_x_forwarded_for',
+      'Access-Control-Allow-Origin $http_origin',
     ],
     location_raw_append => [
       'proxy_pass_header Authorization;',

--- a/modules/profile/manifests/st2server.pp
+++ b/modules/profile/manifests/st2server.pp
@@ -92,14 +92,16 @@ class profile::st2server {
   # Disable HSTS if the user provides a self-signed cert
   $_headers = $_self_signed_cert ? {
     true => {
-      'Front-End-Https'           => 'on',
-      'X-Content-Type-Options'    => 'nosniff',
+      'Front-End-Https'             => 'on',
+      'X-Content-Type-Options'      => 'nosniff',
+      'Access-Control-Allow-Origin' => '*',
     },
     default => {
       'Front-End-Https'           => 'on',
       'X-Content-Type-Options'    => 'nosniff',
       'Strict-Transport-Security' =>
         '"max-age=63072000; includeSubdomains; preload"',
+      'Access-Control-Allow-Origin' => '*',
     }
   }
 

--- a/modules/profile/manifests/st2server.pp
+++ b/modules/profile/manifests/st2server.pp
@@ -561,9 +561,9 @@ class profile::st2server {
     ssl_ciphers          => $_cipher_list,
     server_name          => $_server_names,
     uwsgi                => "unix://${_st2auth_socket}",
-    add_header           => [
-      'Access-Control-Allow-Origin *',
-    ],
+    add_header           => {
+      'Access-Control-Allow-Origin' => '*',
+    },
     proxy_set_header     => [
       'Host $host',
       'X-Real-IP $remote_addr',


### PR DESCRIPTION
This PR ensures that CORS headers are on all sites being served or processed by Nginx. 
