### PR TITLE
Update auth_listen_ip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## In Development
+* Fix: st2auth service not starting on correct IP address (*bugfix*)
 
 ## v0.2.2 / Aug 30, 2015
 * Fix mongodb/rabbitmq OS packages from reinstalling/restarting in a loop (*bugfix*)

--- a/modules/profile/manifests/st2server.pp
+++ b/modules/profile/manifests/st2server.pp
@@ -602,6 +602,7 @@ class profile::st2server {
 
   nginx::resource::vhost { 'st2auth':
     ensure               => present,
+    listen_ip            => $_host_ip,
     listen_port          => $_st2auth_port,
     ssl                  => true,
     ssl_port             => $_st2auth_port,


### PR DESCRIPTION
This PR updates the listening IP for the `nginx::resource::vhost` definition serving `st2auth`. This was modified when moving back to sockets, but this adds extra security for existing services that may be running on this port.
