### PR TITLE
Installer flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## In Development
+* Flag to disable Hubot installation via installer (*improvement*)
 * Fix: st2auth service not starting on correct IP address (*bugfix*)
 * update pip to latest on installation (*improvement*)
 

--- a/modules/role/manifests/st2express.pp
+++ b/modules/role/manifests/st2express.pp
@@ -1,11 +1,15 @@
 class role::st2express {
+  $_enable_hubot = hiera('hubot', true)
+
   include ::profile::infrastructure
   include ::profile::st2server
   include ::profile::users
 
-  if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '6' {
-    notify { 'Hubot is not supported on this platform': }
-  } else {
-    include ::profile::hubot
+  if $_enable_hubot {
+    if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '6' {
+      notify { 'Hubot is not supported on this platform': }
+    } else {
+      include ::profile::hubot
+    }
   }
 }

--- a/script/bootstrap-st2express
+++ b/script/bootstrap-st2express
@@ -3,6 +3,7 @@
 
 PROJECT_ROOT=/opt/puppet
 
+
 # Install Pre-req for git
 if [ -f /usr/bin/apt-get ]; then
   apt-get install -y git
@@ -20,6 +21,11 @@ if [ ! -d ${PROJECT_ROOT}/.git ]; then
   git clone https://github.com/StackStorm/st2workroom ${PROJECT_ROOT}
 fi
 
+# Ability to disable hubot, drop to long-term setting for installer.
+if [ ! -z "$DISABLE_HUBOT" ]; then
+  echo "hubot: false" >> ${PROJECT_ROOT}/hieradata/workroom.yaml
+fi
+
 # Create Facter sink
 if [ ! -d /etc/facter/facts.d ]; then
   echo "Setting up facter.d..."
@@ -35,4 +41,6 @@ ${PROJECT_ROOT}/script/bootstrap-linux
 ${PROJECT_ROOT}/script/puppet-apply
 
 # Check to see if StackStorm is running properly
-${PROJECT_ROOT}/script/check-st2-ok
+if [ -z "$SKIP_OK_CHECK" ]; then
+  ${PROJECT_ROOT}/script/check-st2-ok
+fi


### PR DESCRIPTION
This PR adds various flags to the `st2express-bootstrap` script.
- `DISABLE_HUBOT` - prevents hubot from being installed.
- `SKIP_OK_CHECK` - Disables the OK check at startup (for CI)
