### PR TITLE
Cleanly migrate stand-alone st2api to uWSGI

### DIFF
--- a/modules/role/manifests/st2express.pp
+++ b/modules/role/manifests/st2express.pp
@@ -4,6 +4,7 @@ class role::st2express {
   include ::profile::infrastructure
   include ::profile::st2server
   include ::profile::users
+  class { '::st2migrations': }
 
   if $_enable_hubot {
     if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '6' {

--- a/modules/role/manifests/st2express.pp
+++ b/modules/role/manifests/st2express.pp
@@ -4,7 +4,7 @@ class role::st2express {
   include ::profile::infrastructure
   include ::profile::st2server
   include ::profile::users
-  class { '::st2migrations': }
+  include ::st2migrations
 
   if $_enable_hubot {
     if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '6' {

--- a/modules/st2migrations/manifests/id_2015091401_move_pecan_server_to_uwsgi.pp
+++ b/modules/st2migrations/manifests/id_2015091401_move_pecan_server_to_uwsgi.pp
@@ -1,0 +1,45 @@
+# Migration: Move pecan server to uWSGI
+#
+# Previous iterations of `st2workroom` were built
+# with st2api being controlled via st2ctl. This
+# migration ensures that the existing process is gone
+# so the state applied in Stage['main'] can continue,
+# specifically nginx which now takes over 0.0.0.0
+# where before it only listened on eth0
+class st2migrations::id_2015091401_move_pecan_server_to_uwsgi {
+  $_rundir = $::st2migrations::exec_dir
+
+  if ! $::st2migration_2015091401_move_pecan_server_to_uwsgi {
+    $_shell_script = "#!/usr/bin/env sh
+    service st2api restart
+    ps ax | grep st2api | grep python | awk '{print \$1}' | xargs kill -9"
+
+    file { "${_rundir}/kill_st2api_standalone":
+      ensure  => file,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0755',
+      content => $_shell_script,
+      notify  => Exec['terminate pecan st2api application'],
+    }
+    exec { 'terminate pecan st2api application':
+      command => "${_rundir}/kill_st2api_standalone",
+      path    => [
+        '/usr/bin',
+        '/usr/sbin',
+        '/bin',
+        '/sbin',
+      ],
+      before  => [
+        Facter::Fact['st2migration_2015091401_move_pecan_server_to_uwsgi'],
+        Service['nginx'],
+      ],
+    }
+    facter::fact { 'st2migration_2015091401_move_pecan_server_to_uwsgi':
+      value => 'completed',
+    }
+
+    File<| tag == 'adapter::st2_uwsgi_init' |>
+    -> Exec['terminate pecan st2api application']
+  }
+}

--- a/modules/st2migrations/manifests/init.pp
+++ b/modules/st2migrations/manifests/init.pp
@@ -1,0 +1,13 @@
+class st2migrations (
+  $exec_dir = "${::settings::vardir}/st2migrations",
+) {
+  file { $exec_dir:
+    ensure => directory,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0770',
+  }
+
+  # Register all migrations to activate here
+  include ::st2migrations::id_2015091401_move_pecan_server_to_uwsgi
+}


### PR DESCRIPTION
This PR updates the system to cleanly kill the stand-alone python
application serving out st2api and put up the uWSGI server.

This PR also introduces the concept of "migrations". E.G.: A place to stick nasty transitional code that can be selectively removed from the graph to get you to the state you need in one run.
