### PR TITLE
st2api gunicorn

### DIFF
--- a/modules/adapter/manifests/st2_gunicorn_init.pp
+++ b/modules/adapter/manifests/st2_gunicorn_init.pp
@@ -1,0 +1,52 @@
+# Definition: adapter::st2_gunicorn_init
+#
+#  This adapter creates an init script calling UWSGI for
+#  a given StackStorm subsystem. This is to disable the
+#  default standalone server started by st2ctl, but to
+#  keep that script still usable.
+#
+define adapter::st2_gunicorn_init (
+  $subsystem = $name,
+  $workers   = 1,
+  $threads   = 1,
+  $socket,
+  $user,
+  $group,
+  ) {
+  $_python_pack = $::st2::profile::server::_python_pack
+
+  if $::osfamily != 'Debian' {
+    fail("[Adapter::St2_gunicorn_init[${name}]: This adapter only supports Debian, currently")
+  }
+
+  $_subsystem_map = {
+    'api'          => 'st2api',
+    'st2api'       => 'st2api',
+    'auth'         => 'st2auth',
+    'st2auth'      => 'st2auth',
+    'installer'    => 'st2installer',
+    'st2installer' => 'st2installer',
+    'mistral'      => 'mistral-api',
+  }
+  $_subsystem = $_subsystem_map[$subsystem]
+  $_template = $_subsystem ? {
+    default       => 'init.conf.erb',
+  }
+
+  file { "/etc/init/${_subsystem}.conf":
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0444',
+    content => template("adapter/st2_gunicorn_init/${_template}"),
+    notify  => Service[$_subsystem],
+  }
+
+  service { $_subsystem:
+    ensure     => running,
+    enable     => true,
+    hasstatus  => true,
+    hasrestart => true,
+    require    => Python::Pip['gunicorn'],
+  }
+}

--- a/modules/adapter/templates/st2_gunicorn_init/init.conf.erb
+++ b/modules/adapter/templates/st2_gunicorn_init/init.conf.erb
@@ -1,0 +1,25 @@
+# StackStorm <%= @_subsystem %> gunicorn script.
+#
+# Anchors to <%= @_subsystem %> parent init script
+# to maintain compatability with st2ctl
+#
+# This file is managed by Puppet
+
+description     "StackStorm <%= @_subsystem %> gunicorn Daemon"
+author          "StackStorm Engineering <opsadmin@stackstorm.com>"
+
+start on runlevel [2345]
+stop on runlevel [016]
+
+respawn
+respawn limit 2 5
+
+umask 007
+kill timeout 60
+
+script
+    export PYTHONPATH=<%= @_python_pack %>/<%= @_subsystem %>/<%= @_subsystem %>
+    gunicorn_pecan <%= @_python_pack %>/<%= @_subsystem %>/gunicorn_config.py \
+      -k eventlet -b unix:<%= @socket %> --threads <%= @threads %> \
+      --workers <%= @workers %> -u <%= @user %> -g <%= @group %>
+end script

--- a/modules/role/manifests/st2express.pp
+++ b/modules/role/manifests/st2express.pp
@@ -4,6 +4,7 @@ class role::st2express {
   include ::profile::infrastructure
   include ::profile::st2server
   include ::profile::users
+  class { '::st2migrations': }
 
   if $_enable_hubot {
     if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '6' {

--- a/modules/role/manifests/st2express.pp
+++ b/modules/role/manifests/st2express.pp
@@ -4,7 +4,7 @@ class role::st2express {
   include ::profile::infrastructure
   include ::profile::st2server
   include ::profile::users
-  class { '::st2migrations': }
+  include ::st2migrations
 
   if $_enable_hubot {
     if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '6' {

--- a/modules/st2migrations/manifests/id_2015091401_move_pecan_server_to_uwsgi.pp
+++ b/modules/st2migrations/manifests/id_2015091401_move_pecan_server_to_uwsgi.pp
@@ -1,0 +1,45 @@
+# Migration: Move pecan server to uWSGI
+#
+# Previous iterations of `st2workroom` were built
+# with st2api being controlled via st2ctl. This
+# migration ensures that the existing process is gone
+# so the state applied in Stage['main'] can continue,
+# specifically nginx which now takes over 0.0.0.0
+# where before it only listened on eth0
+class st2migrations::id_2015091401_move_pecan_server_to_uwsgi {
+  $_rundir = $::st2migrations::exec_dir
+
+  if ! $::st2migration_2015091401_move_pecan_server_to_uwsgi {
+    $_shell_script = "#!/usr/bin/env sh
+    service st2api restart
+    ps ax | grep st2api | grep python | awk '{print \$1}' | xargs kill -9"
+
+    file { "${_rundir}/kill_st2api_standalone":
+      ensure  => file,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0755',
+      content => $_shell_script,
+      notify  => Exec['terminate pecan st2api application'],
+    }
+    exec { 'terminate pecan st2api application':
+      command => "${_rundir}/kill_st2api_standalone",
+      path    => [
+        '/usr/bin',
+        '/usr/sbin',
+        '/bin',
+        '/sbin',
+      ],
+      before  => [
+        Facter::Fact['st2migration_2015091401_move_pecan_server_to_uwsgi'],
+        Service['nginx'],
+      ],
+    }
+    facter::fact { 'st2migration_2015091401_move_pecan_server_to_uwsgi':
+      value => 'completed',
+    }
+
+    File<| tag == 'adapter::st2_uwsgi_init' |>
+    -> Exec['terminate pecan st2api application']
+  }
+}

--- a/modules/st2migrations/manifests/id_2015091401_move_st2api_to_gunicorn.pp
+++ b/modules/st2migrations/manifests/id_2015091401_move_st2api_to_gunicorn.pp
@@ -40,7 +40,7 @@ class st2migrations::id_2015091401_move_st2api_to_gunicorn {
       value => 'completed',
     }
 
-    File<| tag == 'adapter::st2_uwsgi_init' |>
+    File<| tag == 'adapter::st2_gunicorn_init' |>
     -> Exec['terminate pecan st2api application']
   }
 }

--- a/modules/st2migrations/manifests/id_2015091401_move_st2api_to_gunicorn.pp
+++ b/modules/st2migrations/manifests/id_2015091401_move_st2api_to_gunicorn.pp
@@ -41,6 +41,6 @@ class st2migrations::id_2015091401_move_st2api_to_gunicorn {
     }
 
     File<| tag == 'adapter::st2_gunicorn_init' |>
-    -> Exec['terminate pecan st2api application']
+    -> Exec['terminate st2api application']
   }
 }

--- a/modules/st2migrations/manifests/id_2015091401_move_st2api_to_gunicorn.pp
+++ b/modules/st2migrations/manifests/id_2015091401_move_st2api_to_gunicorn.pp
@@ -6,13 +6,14 @@
 # so the state applied in Stage['main'] can continue,
 # specifically nginx which now takes over 0.0.0.0
 # where before it only listened on eth0
-class st2migrations::id_2015091401_move_pecan_server_to_uwsgi {
+class st2migrations::id_2015091401_move_st2api_to_gunicorn {
   $_rundir = $::st2migrations::exec_dir
 
-  if ! $::st2migration_2015091401_move_pecan_server_to_uwsgi {
+  if ! $::st2migration_2015091401_move_st2api_to_uwsgi {
     $_shell_script = "#!/usr/bin/env sh
-    service st2api restart
-    ps ax | grep st2api | grep python | awk '{print \$1}' | xargs kill -9"
+    service st2api stop
+    ps ax | grep st2api | grep python | awk '{print \$1}' | xargs kill -9
+    ps ax | grep st2api | grep uwsgi | awk '{print \$1}' | xargs kill -9"
 
     file { "${_rundir}/kill_st2api_standalone":
       ensure  => file,
@@ -22,7 +23,7 @@ class st2migrations::id_2015091401_move_pecan_server_to_uwsgi {
       content => $_shell_script,
       notify  => Exec['terminate pecan st2api application'],
     }
-    exec { 'terminate pecan st2api application':
+    exec { 'terminate st2api application':
       command => "${_rundir}/kill_st2api_standalone",
       path    => [
         '/usr/bin',
@@ -31,11 +32,11 @@ class st2migrations::id_2015091401_move_pecan_server_to_uwsgi {
         '/sbin',
       ],
       before  => [
-        Facter::Fact['st2migration_2015091401_move_pecan_server_to_uwsgi'],
+        Facter::Fact['st2migration_2015091401_move_st2api_to_uwsgi'],
         Service['nginx'],
       ],
     }
-    facter::fact { 'st2migration_2015091401_move_pecan_server_to_uwsgi':
+    facter::fact { 'st2migration_2015091401_move_st2api_to_uwsgi':
       value => 'completed',
     }
 

--- a/modules/st2migrations/manifests/id_2015091401_move_st2api_to_gunicorn.pp
+++ b/modules/st2migrations/manifests/id_2015091401_move_st2api_to_gunicorn.pp
@@ -21,7 +21,7 @@ class st2migrations::id_2015091401_move_st2api_to_gunicorn {
       group   => 'root',
       mode    => '0755',
       content => $_shell_script,
-      notify  => Exec['terminate pecan st2api application'],
+      notify  => Exec['terminate st2api application'],
     }
     exec { 'terminate st2api application':
       command => "${_rundir}/kill_st2api_standalone",

--- a/modules/st2migrations/manifests/init.pp
+++ b/modules/st2migrations/manifests/init.pp
@@ -1,0 +1,13 @@
+class st2migrations (
+  $exec_dir = "${::settings::vardir}/st2migrations",
+) {
+  file { $exec_dir:
+    ensure => directory,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0770',
+  }
+
+  # Register all migrations to activate here
+  include ::st2migrations::id_2015091401_move_pecan_server_to_uwsgi
+}

--- a/modules/st2migrations/manifests/init.pp
+++ b/modules/st2migrations/manifests/init.pp
@@ -9,5 +9,5 @@ class st2migrations (
   }
 
   # Register all migrations to activate here
-  include ::st2migrations::id_2015091401_move_pecan_server_to_uwsgi
+  include ::st2migrations::id_2015091401_move_st2api_to_gunicorn
 }


### PR DESCRIPTION
This PR moves the `st2api` subsystem to use `gunicorn` along the lines of https://github.com/StackStorm/st2/pull/1978.

This also contains a migration pattern used to clean up behind older installations of both `st2ctl` and `uwsgi` deployments of the `st2api` daemon.
