### PR TITLE
Misc Fixes

### DIFF
--- a/modules/profile/manifests/st2server.pp
+++ b/modules/profile/manifests/st2server.pp
@@ -986,12 +986,12 @@ class profile::st2server {
 
   # Configure public url to the API endpoint.
   ini_setting { 'configure_api_public_url':
-    ensure => present,
-    path   => '/etc/st2/st2.conf',
+    ensure  => present,
+    path    => '/etc/st2/st2.conf',
     section => 'auth',
     setting => 'api_url',
     value   => $_public_api_url,
-    ensure  => Class['::st2::profile::server'],
+    require => Class['::st2::profile::server'],
   }
 
   ## Perms fix for /var/log/st2.  Needs to be added to mainline puppet module

--- a/modules/st2migrations/manifests/id_2015092201_disable_mistral_nginx.pp
+++ b/modules/st2migrations/manifests/id_2015092201_disable_mistral_nginx.pp
@@ -11,8 +11,11 @@ class st2migrations::id_2015092201_disable_mistral_nginx {
 
   if $::st2migration_2015092201_disable_mistral_nginx != 'completed-2x' {
     $_shell_script = "#!/usr/bin/env sh
-      rm -rf /etc/nginx/sites-enabled/mistral-api.conf
-      service nginx stop
+      if [ -f /etc/nginx/sites-enabled/mistral-api.conf ]; then
+        rm -rf /etc/nginx/sites-enabled/mistral-api.conf
+      fi
+
+      service nginx stop || true
     "
 
     file { "${_rundir}/remove_mistral_nginx_config":


### PR DESCRIPTION
This PR commits a few fixes that prevented `st2workroom` from provisioning cleaning on a new node. 
