### PR TITLE
Use correct directory for st2installer venv

### DIFF
--- a/modules/profile/manifests/st2server.pp
+++ b/modules/profile/manifests/st2server.pp
@@ -857,7 +857,7 @@ class profile::st2server {
     version      => 'system',
     systempkgs   => false,
     venv_dir     => "${_st2installer_root}/.venv",
-    cwd          => $_mistral_root,
+    cwd          => $_st2installer_root,
     requirements => "${_st2installer_root}/requirements.txt",
     require      => Vcsrepo[$_st2installer_root],
     before       => Service['st2installer'],


### PR DESCRIPTION
This commit updates the Python::Virtualenv resource for st2installer
to use the root directory of the cloned repo versus Mistral root.

Fixes #119
