### PR TITLE
Fixed typographical error, changed attemt to attempt in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ users:
 
 ## Known Issues
 
-Unfortunately, as seamless as we attemt to make this project, there are a few issues that we cannot code around. But, they're easy enough to fix, and your solution might be listed below.
+Unfortunately, as seamless as we attempt to make this project, there are a few issues that we cannot code around. But, they're easy enough to fix, and your solution might be listed below.
 
 ### IP Conflicts
 In the event you receive an error related to IP conflict, Edit the `private_neworks` address in `stacks/st2.yaml`, and adjust the third octet to a non-conflicting value. For example:


### PR DESCRIPTION
@StackStorm, I've corrected a typographical error in the documentation of the [st2workroom](https://github.com/StackStorm/st2workroom) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
