### PR TITLE
puppet-apply requires ruby > 1.9.3 on RHEL6

### DIFF
--- a/script/shared-functions
+++ b/script/shared-functions
@@ -45,5 +45,5 @@ fi
 
 install_rvm() {
   curl -sSL https://rvm.io/mpapis.asc | sudo gpg2 --import -
-  curl -sSL https://get.rvm.io | bash -s stable --ruby=1.9.3
+  curl -sSL https://get.rvm.io | bash -s stable --ruby=2.0.0
 }


### PR DESCRIPTION
This moved the needle. 

I had to also do gem install bunder. I am not sure where to add that to puppet. 

Also, got puppet-apply got stuck at

```
[21:15:39] Resetting branch environment to origin/master
[21:15:39] HEAD is now at 0235287 Merge pull request #123 from StackStorm/backport-st2enterprise
[21:15:39] 0235287ee64f5bbe83a1ff8c59fb176f81b2b0bf
[21:15:39] Environment master is currently on 0235287ee64f5bbe83a1ff8c59fb176f81b2b0bf
[21:15:39] Deploying new branch environment master
[21:15:39] Creating production symlinks
Error: Could not run: Could not find file /opt/puppet/environments/production/manifests
[root@st2w-master-el6-560f77c782fb9b0bb51dddb1 lakshmi]#
```
