### PR TITLE
ensure bundler is installed for RVM installs

### DIFF
--- a/script/shared-functions
+++ b/script/shared-functions
@@ -46,4 +46,5 @@ fi
 install_rvm() {
   curl -sSL https://rvm.io/mpapis.asc | sudo gpg2 --import -
   curl -sSL https://get.rvm.io | bash -s stable --ruby=2.0.0
+  gem install bundler
 }


### PR DESCRIPTION
This PR adds `bundler` to the OS bootstrap scripts if RVM is used to install ruby. Usually on older hosts (e.g.: RHEL 6.x)

/cc @lakshmi-kannan #125 
