### PR TITLE
Check if bootstrap-st2express is runned from root

### DIFF
--- a/script/bootstrap-st2express
+++ b/script/bootstrap-st2express
@@ -3,6 +3,11 @@
 
 PROJECT_ROOT=/opt/puppet
 
+if [[ $EUID != 0 ]]; then
+  echo 'StackStorm installation requires superuser access rights!'
+  echo 'Please run with sudo or from root user.'
+  exit 1
+fi
 
 # Install Pre-req for git
 if [ -f /usr/bin/apt-get ]; then


### PR DESCRIPTION
``` sh
#curl -sSL https://raw.githubusercontent.com/StackStorm/st2workroom/master/script/bootstrap-st2express | sh

E: Could not open lock file /var/lib/dpkg/lock - open (13: Permission denied)
E: Unable to lock the administration directory (/var/lib/dpkg/), are you root?
./bootstrap-st2express: line 21: git: command not found
Setting up facter.d...
mkdir: cannot create directory ‘/etc/facter’: Permission denied
./bootstrap-st2express: line 35: /etc/facter/facts.d/role.txt: No such file or directory
./bootstrap-st2express: line 38: /opt/puppet/script/bootstrap-os: No such file or directory
./bootstrap-st2express: line 41: /opt/puppet/script/puppet-apply: No such file or directory
./bootstrap-st2express: line 45: /opt/puppet/script/check-st2-ok: No such file or directory
```

is not very user-friendly message
