### PR TITLE
Remove service management for puppet/mco

### DIFF
--- a/modules/puppet/manifests/masterless.pp
+++ b/modules/puppet/manifests/masterless.pp
@@ -52,9 +52,4 @@ class puppet::masterless(
     ensure => link,
     target => "${::settings::confdir}/script/puppet-apply",
   }
-
-  service { ['puppet', 'mcollective']:
-    ensure => stopped,
-    enable => false,
-  }
 }


### PR DESCRIPTION
When using the AIO installer, there is no daemon running. This is only an artifact of how StackStorm uses st2puppet and puppet-st2 together.
