### PR TITLE
source ST2 ENV variables to check St2

### DIFF
--- a/script/check-st2-ok
+++ b/script/check-st2-ok
@@ -2,6 +2,7 @@
 
 DIR=$( dirname "$(readlink -f "$0")" )
 . $DIR/shared-functions
+. /etc/profile.d/st2.sh
 
 ST2_PATH=`which st2`
 


### PR DESCRIPTION
This PR ensures that the StackStorm env variables for the proper HTTP endpoints are loaded during the check script.
