### PR TITLE
use SCL to provide ruby for RHEL 6

### DIFF
--- a/script/bootstrap-redhat
+++ b/script/bootstrap-redhat
@@ -8,8 +8,9 @@ PACKAGES=""
 
 if [ $MAJORVER = "6" ]; then
     EPEL="https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
-    RBEL="http://rbel.frameos.org/rbel6"
-    PACKAGES="rubygems glibc glibc-headers glibc-devel nscd nc git unzip curl"
+    PACKAGES="scl-utils ruby193 ruby193-ruby-devel glibc glibc-headers glibc-devel nscd nc git unzip curl"
+    SCL="http://people.redhat.com/bkabrda/scl_ruby193.repo"
+
 elif [ $MAJORVER = "7" ]; then
     EPEL="https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
     PACKAGES="ruby ruby-devel rubygem-bundler unzip curl git-core"
@@ -20,9 +21,12 @@ if [ -n "$EPEL" ]; then
     rpm -ivh $EPEL
 fi
 
-if [ -n "$RBEL" ]; then
-    rpm -ivh $RBEL
+# If we're using the Software Collection Library, downlad the repo
+# and get it ready for usage
+if [ -n "$SCL" ]; then
+    wget $SCL -O /etc/yum.repos.d/scl_ruby193.repo
 fi
+
 
 yum clean all
 yum clean dbcache

--- a/script/puppet-apply
+++ b/script/puppet-apply
@@ -65,12 +65,12 @@ else
 fi
 
 # Setup Puppet environments
+mkdir -p $PROJECT_ROOT/environments
 if [ "$PUPPET_ENV" = "current_working_directory" ]; then
     # Make sure the current working directory is an environment too!
     # This is sort of a hack to support environments while developing
     # on the currently active branch in Vagrant or other environments
     echo "Setting up 'current_working_directory'..."
-    mkdir -p $PROJECT_ROOT/environments
     rsync $RSYNC_DEBUG_ARGS -arh --delete --exclude "environments" \
           --exclude "vendor" --exclude "artifacts" --exclude "graphs" \
           --exclude "packer" --exclude "script" --exclude ".git" \

--- a/script/shared-functions
+++ b/script/shared-functions
@@ -5,12 +5,10 @@
 # DIR=$( dirname "$(readlink -f "$0")" )
 # . $DIR/shared-functions
 
-# Some OSes just don't have Ruby, so we gotta get it
-if [ -f /etc/profile.d/rvm.sh ]; then
-  . /etc/profile.d/rvm.sh
-fi
-if [ -f /usr/local/rvm/scripts/rvm ]; then
-  . /usr/local/rvm/scripts/rvm
+# On hosts that use RH Software collections, ensure that
+# the profile is up and ready to go to source ruby.
+if [ -f /opt/rh/ruby193/enable ]; then
+  . /opt/rh/ruby193/enable
 fi
 
 PROJECT_ROOT=/opt/puppet
@@ -42,9 +40,3 @@ elif [ "$OS" = "Linux" ]; then
     CODENAME=`/usr/bin/lsb_release -c -s`
 	fi
 fi
-
-install_rvm() {
-  curl -sSL https://rvm.io/mpapis.asc | sudo gpg2 --import -
-  curl -sSL https://get.rvm.io | bash -s stable --ruby=2.0.0
-  gem install bundler
-}


### PR DESCRIPTION
RVM was messy, so let's use the officially supported Software Collection Library to provide the ruby needed.

This PR updates the bootstrap scripts for RHEL 6 to use SCL for satisfying puppet deps.
