### PR TITLE
use plain old IP address for RHEL 7, because SystemD

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -13,6 +13,8 @@
   - "stack/role/%{::role}"
   - "stack/datacenter/%{::datacenter}"
   - "stack/%{::stack}"
+  - "operatingsystem/%{::operatingsystem}/%{::operatingsystemmajrelease}"
+  - "operatingsystem/%{::operatingsystem}"
   - "osfamily/%{::osfamily}"
   - "datacenter/%{::datacenter}"
   - common

--- a/hieradata/operatingsystem/RedHat/7.yaml
+++ b/hieradata/operatingsystem/RedHat/7.yaml
@@ -1,0 +1,2 @@
+---
+system::ipaddress: "%{::ipaddress}"


### PR DESCRIPTION
Adds a special override for RHEL 7 and systemd
