### PR TITLE
Set a default private network for st2testing

### DIFF
--- a/stacks/st2testing.yaml
+++ b/stacks/st2testing.yaml
@@ -7,6 +7,8 @@ defaults: &defaults
   puppet:
     facts:
       role: norole
+  private_networks:
+    - 192.168.60.40
 ubuntu1404:
   <<: *defaults
   hostname: ubuntu1404


### PR DESCRIPTION
Went with 192.168 because Docker. 
