### PR TITLE
Setup config for user running the bootstarp script

### DIFF
--- a/script/bootstrap-st2express
+++ b/script/bootstrap-st2express
@@ -104,6 +104,16 @@ fi
 # Converge the system
 ${PROJECT_ROOT}/script/puppet-apply
 
+# Place CLI config file with correct base_url for local user.
+CLI_CONFIG_RC_FILE_PATH=${HOME}/.st2/config
+if [ ! -f "${CLI_CONFIG_RC_FILE_PATH}" ]; then
+  bash -c "cat > ${CLI_CONFIG_RC_FILE_PATH}" <<EOL
+[general]
+base_url = https://127.0.0.1
+
+EOL
+fi
+
 # Check to see if StackStorm is running properly
 if [ -z "$SKIP_OK_CHECK" ]; then
   ${PROJECT_ROOT}/script/check-st2-ok

--- a/script/bootstrap-st2express
+++ b/script/bootstrap-st2express
@@ -105,8 +105,10 @@ fi
 ${PROJECT_ROOT}/script/puppet-apply
 
 # Place CLI config file with correct base_url for local user.
-CLI_CONFIG_RC_FILE_PATH=${HOME}/.st2/config
+CLI_CONFIG_RC_FILE_DIR=${HOME}/.st2
+CLI_CONFIG_RC_FILE_PATH=${CLI_CONFIG_RC_FILE_DIR}/config
 if [ ! -f "${CLI_CONFIG_RC_FILE_PATH}" ]; then
+  mkdir -p ${CLI_CONFIG_RC_FILE_DIR}
   bash -c "cat > ${CLI_CONFIG_RC_FILE_PATH}" <<EOL
 [general]
 base_url = https://127.0.0.1


### PR DESCRIPTION
- The argument is that the user will try to run some st2 command
  immediately after running this install script and will see failures
  as the API will be on https. Although likely a terrible place to do
  this but I cannot tell how to pull this off with puppet.
