### PR TITLE
Write default admin RBAC role assignment for chatops_bot user

### DIFF
--- a/modules/profile/manifests/st2rbac.pp
+++ b/modules/profile/manifests/st2rbac.pp
@@ -5,6 +5,7 @@ class profile::st2rbac {
   $_enterprise_token = hiera('st2enterprise::token', undef)
 
   $_root_cli_username = $::profile::st2server::_root_cli_username
+  $_chatops_bot_username = 'chatops_bot'
 
   if $_enterprise_token {
     ini_setting { 'disable st2 rbac':
@@ -24,6 +25,13 @@ class profile::st2rbac {
       ]
     }
 
+    # Create default admin role assignment for ChatOps user
+    st2::rbac { $_chatops_bot_username:
+      description  => 'Default admin role assignment created by the installer',
+      roles        => [
+          'admin'
+      ]
+    }
     # Create default system_admin role assignment for admin user created during installation
     # Note: Assignment is only created once the installer has completed.
     $_users = hiera_hash('users', {}).keys()
@@ -31,7 +39,7 @@ class profile::st2rbac {
         $_admin_user = $_users[0]
 
         st2::rbac { $_admin_user:
-          description  => 'Default system_admin role assignments created by the installer',
+          description  => 'Default system_admin role assignment created by the installer',
           roles        => [
               'system_admin'
           ]

--- a/modules/profile/manifests/st2rbac.pp
+++ b/modules/profile/manifests/st2rbac.pp
@@ -4,8 +4,9 @@
 class profile::st2rbac {
   $_enterprise_token = hiera('st2enterprise::token', undef)
 
+  $_hubot_data = hiera('hubot::env_export')
   $_root_cli_username = $::profile::st2server::_root_cli_username
-  $_chatops_bot_username = 'chatops_bot'
+  $_chatops_bot_username = $_hubot_data['ST2_AUTH_USERNAME']
 
   if $_enterprise_token {
     ini_setting { 'disable st2 rbac':


### PR DESCRIPTION
While reviewing and testing RBAC changes I noticed we don't write a default admin role assignment for the StackStorm user (`chatops_bot`) which is used for ChatOps which breaks stuff when RBAC is enabled since /aliasexecution is behind RBAC for.

For now, we simply write an admin role assignment, but eventually we will want to improve that:
1. When we add support for gloving ("_") in resource_uid, we should update the definition to only grant "action_execute" on "pack:_" and "action_alias_list/view" on "actionalias:*"
2. Once we start working on first-class citizen RBAC support for ChatOps, permissions will be inherited by the user which executed a ChatOps command.

Second step takes quite a lot of work (and we still need to figure out and decide on some things) so the incremental path is doing option 1 first, since globbing support will also come handy in other places, especially when we add support for RBAC on datastore items.
