### PR TITLE
Enable RBAC in st2rbac manifest if enterprise token is defined

### DIFF
--- a/modules/profile/manifests/st2rbac.pp
+++ b/modules/profile/manifests/st2rbac.pp
@@ -4,9 +4,7 @@
 class profile::st2rbac {
   $_enterprise_token = hiera('st2enterprise::token', undef)
 
-  $_hubot_data = hiera('hubot::env_export')
   $_root_cli_username = $::profile::st2server::_root_cli_username
-  $_chatops_bot_username = $_hubot_data['ST2_AUTH_USERNAME']
 
   if $_enterprise_token {
     ini_setting { 'disable st2 rbac':
@@ -27,12 +25,17 @@ class profile::st2rbac {
     }
 
     # Create default admin role assignment for ChatOps user
-    st2::rbac { $_chatops_bot_username:
-      description  => 'Default admin role assignment created by the installer',
-      roles        => [
-          'admin'
-      ]
+    $_hubot_data = hiera_hash('hubot::env_export', {})
+    if size($_hubot_data.keys()) >= 1 {
+        $_chatops_bot_username = $_hubot_data['ST2_AUTH_USERNAME']
+        st2::rbac { $_chatops_bot_username:
+          description  => 'Default admin role assignment created by the installer',
+          roles        => [
+              'admin'
+          ]
+        }
     }
+
     # Create default system_admin role assignment for admin user created during installation
     # Note: Assignment is only created once the installer has completed.
     $_users = hiera_hash('users', {}).keys()

--- a/modules/profile/manifests/st2rbac.pp
+++ b/modules/profile/manifests/st2rbac.pp
@@ -1,6 +1,6 @@
 # Class: profile::st2rbac
 #
-# Enable RBAC for StackStorm and write default role asignments.
+# Enable RBAC for StackStorm and write default role assignments.
 class profile::st2rbac {
   $_enterprise_token = hiera('st2enterprise::token', undef)
   if $_enterprise_token {

--- a/modules/profile/manifests/st2rbac.pp
+++ b/modules/profile/manifests/st2rbac.pp
@@ -1,22 +1,20 @@
 # Class: profile::st2rbac
 #
-# Enable RBAC for StackStorm
+# Enable RBAC for StackStorm and write default role asignments.
 class profile::st2rbac {
   $_enterprise_token = hiera('st2enterprise::token', undef)
-
-  $_root_cli_username = $::profile::st2server::_root_cli_username
-
   if $_enterprise_token {
-    ini_setting { 'disable st2 rbac':
+    # Enable RBAC if enterprise token is present, write default role assignments
+    ini_setting { 'enable st2 rbac':
       ensure  => present,
       path    => '/etc/st2/st2.conf',
       section => 'rbac',
       setting => 'enable',
-      value   => 'False',
+      value   => 'True',
       require => Class['::profile::st2server'],
-    }
 
     # Create default admin role assignment for root_cli user
+    $_root_cli_username = $::profile::st2server::_root_cli_username
     st2::rbac { $_root_cli_username:
       description  => 'Default admin role assignments created by the installer',
       roles        => [
@@ -48,6 +46,7 @@ class profile::st2rbac {
               'system_admin'
           ]
         }
+      }
     }
   }
 }


### PR DESCRIPTION
- Enable RBAC in st2rbac manifest if enterprise token is defined
- Only write role assignments if token is defined
- Only write hubot user role assignment if hubot specific answers are present
