### PR TITLE
Make sure the YAML hiera datadir matches the JSON one

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -2,7 +2,7 @@
   - json
   - yaml
 :yaml:
-  :datadir: /opt/puppet/environments/%{::environment}/hieradata
+  :datadir: /opt/puppet/hieradata
 :json:
   :datadir: /opt/puppet/hieradata
 :hierarchy:


### PR DESCRIPTION
Make sure the YAML hiera datadir matches the JSON one otherwise loading answers from answer.yaml passed to bootstrap script won't work for non JSON files.
