### PR TITLE
Re-enable auth manager

### DIFF
--- a/modules/profile/manifests/auth_backend_pam.pp
+++ b/modules/profile/manifests/auth_backend_pam.pp
@@ -1,0 +1,42 @@
+# == Class: st2::profile::auth_backend_pam
+#
+#  Profile to install StackStorm Enterprise Auth Backends. This feature is
+#  currently under active development, and limited to early access users.
+#  If you would like to try this out, please send an email to support@stackstorm.com
+#  and let us know!
+#
+# === Parameters
+#
+#  [*version*]      - Version of StackStorm Auth Backend to install
+#
+# === Variables
+#
+#  This class has no variables
+#
+# === Examples
+#
+#  include ::profile::auth_backend_pam
+#
+class profile::auth_backend_pam(
+  $version = '0.1.0',
+) inherits st2 {
+
+  $distro_path = $osfamily ? {
+    'Debian' => "apt/${lsbdistcodename}",
+    'Ubuntu' => "apt/${lsbdistcodename}",
+    'RedHat' => "yum/el/${operatingsystemmajrelease}"
+  }
+
+  wget::fetch { "Download auth pam backend":
+    source      => "https://downloads.stackstorm.net/st2community/${distro_path}/auth_backends/st2_auth_backend_pam-${version}-py2.7.egg",
+    cache_dir   => '/var/cache/wget',
+    destination => "/tmp/st2_auth_backend_pam-${version}-py2.7.egg"
+  }
+
+  exec { 'install auth backend':
+    command => "easy_install /tmp/st2_auth_backend_pam-${version}-py2.7.egg",
+    path    => '/usr/bin:/usr/sbin:/bin:/sbin',
+    require => Wget::Fetch["Download auth pam backend"]
+  }
+
+}

--- a/modules/role/manifests/st2dev.pp
+++ b/modules/role/manifests/st2dev.pp
@@ -3,4 +3,5 @@ class role::st2dev {
   include ::profile::st2_dependencies
   include ::profile::hubot
   include ::profile::users
+  include ::profile::auth_backend_pam
 }

--- a/modules/role/manifests/st2express.pp
+++ b/modules/role/manifests/st2express.pp
@@ -3,8 +3,16 @@ class role::st2express {
 
   include ::profile::infrastructure
   include ::profile::st2server
+  include ::profile::auth_backend_pam
   include ::profile::users
   include ::st2migrations
+
+  st2::helper::auth_manager {
+    auth_mode     => 'standalone',
+    auth_backend  => 'pam',
+    debug         => false,
+    test_user     => false
+  }
 
   if $_enable_hubot {
     include ::profile::hubot


### PR DESCRIPTION
Reverts StackStorm/st2workroom#178

This PR re-adds what was originally added by @lakshmi-kannan in #171. The error upstream was fixed by @DoriftoShoes in https://github.com/StackStorm/puppet-st2/commit/625ef279e55e9140929e63daf19401498ad8580a#commitcomment-13796053.

Essentially, defined type _must_ declare a resource, or else failures abound as seen.
