### PR TITLE
Update rsyslog to also listen on TCP port 515

### DIFF
--- a/modules/profile/manifests/rsyslog.pp
+++ b/modules/profile/manifests/rsyslog.pp
@@ -12,6 +12,18 @@ class profile::rsyslog {
     notify => Service['rsyslog']
   }
 
+  # Note: We also listen on TCP so long messages are notr truncated
+  file_line{'$ModLoad imtcp':
+    path   => '/etc/rsyslog.conf',
+    line   => '$ModLoad imtcp',
+    notify => Service['rsyslog']
+  }
+  file_line{'$InputTCPServerRun 515':
+    path => '/etc/rsyslog.conf',
+    line => '$InputTCPServerRun 515',
+    notify => Service['rsyslog']
+  }
+
   # Ensure latest version of rsyslogd is available for RHEL 6 systems
   if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '6' {
     wget::fetch { 'rsyslogd repo':

--- a/modules/profile/manifests/rsyslog.pp
+++ b/modules/profile/manifests/rsyslog.pp
@@ -12,7 +12,7 @@ class profile::rsyslog {
     notify => Service['rsyslog']
   }
 
-  # Note: We also listen on TCP so long messages are notr truncated
+  # Note: We also listen on TCP so long messages are not truncated
   file_line{'$ModLoad imtcp':
     path   => '/etc/rsyslog.conf',
     line   => '$ModLoad imtcp',

--- a/modules/profile/manifests/st2server.pp
+++ b/modules/profile/manifests/st2server.pp
@@ -1043,6 +1043,25 @@ class profile::st2server {
     require => Class['::st2::profile::server'],
   }
 
+  # Configure st2 services to use TCP syslog transport
+  ini_setting { 'configure_st2_to_use_tcp_syslog_transport':
+    ensure => present,
+    path   => '/etc/st2/st2.conf',
+    section => 'syslog',
+    setting => 'protocol',
+    value   => 'tcp',
+    require => Class['::st2::profile::server'],
+  }
+
+  ini_setting { 'configure_st2_to_use_tcp_515_syslog_transport_port':
+    ensure => present,
+    path   => '/etc/st2/st2.conf',
+    section => 'syslog',
+    setting => 'port',
+    value   => '515',
+    require => Class['::st2::profile::server'],
+  }
+
   ## Perms fix for /var/log/st2.  Needs to be added to mainline puppet module
   file { '/var/log/st2':
     ensure  => 'directory',


### PR DESCRIPTION
Right now long messages are getting truncated.

I still need to update st2.conf to utilize the TCP transport.
