### PR TITLE
Update nodejs to 0.12

### DIFF
--- a/modules/profile/manifests/hubot.pp
+++ b/modules/profile/manifests/hubot.pp
@@ -5,7 +5,9 @@ class profile::hubot(
   class { '::hubot':
     install_nodejs => false,
   }
-  class { '::nodejs': }
+  class { '::nodejs': 
+    repo_url_suffix => 'node_0.12',
+  }
 
   $_hubot_bin_dir = '/opt/hubot/hubot'
   $_hubot_user    = 'hubot'


### PR DESCRIPTION
Node.js 0.10 is in maintenance mode and approaching end of life. st2client 0.4.0 will likely drop support of it (unless we won't be able to deploy 0.12 in some of our environments).

This PR is can wait until after 1.0 release to avoid introducing last moment incompatibilities.
