### PR TITLE
Support of optional vagrant-bindfs plugin

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -191,6 +191,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |vagrant|
           local_mount ||= [DIR, 'mounts', vm_mount.gsub(/\//, '_')].join('/')
           FileUtils.mkdir_p local_mount
           n.vm.synced_folder local_mount, vm_mount, type: config['sync_type']
+          if Vagrant.has_plugin?('vagrant-bindfs')
+            n.bindfs.bind_folder vm_mount, vm_mount
+          end
         end
       end
 


### PR DESCRIPTION
The plugin solves the problem with chmod\chown over nfs share and required for `npm link` to work on shared folders, which in turn makes it much easier to develop `hubot-stackstorm` module by having sources on the host system and link the module to `/opt/hubot/hubot`.
