### PR TITLE
Fix bootstrap on Ubuntu 14.04 - add missing package dependencies for ruby-augeas

### DIFF
--- a/script/bootstrap-debian
+++ b/script/bootstrap-debian
@@ -13,6 +13,9 @@ if [ "$CODENAME" = "wheezy" ]; then
 elif [ "$CODENAME" = "precise" ]; then
     BUILD_RUBY=true
     GEM_BUNDLER=true
+    # Note: pkg-config, libaugeas-dev and augeas-tools are needed to build 
+    # ruby-augeas gem
+    PACKAGES="$PACKAGES pkg-config libaugeas-dev augeas-tools"
     unset RUBY_PACKAGES
 else
     PACKAGES="ruby-bundler $PACKAGES"

--- a/script/bootstrap-debian
+++ b/script/bootstrap-debian
@@ -13,12 +13,11 @@ if [ "$CODENAME" = "wheezy" ]; then
 elif [ "$CODENAME" = "precise" ]; then
     BUILD_RUBY=true
     GEM_BUNDLER=true
-    # Note: pkg-config, libaugeas-dev and augeas-tools are needed to build 
-    # ruby-augeas gem
-    PACKAGES="$PACKAGES pkg-config libaugeas-dev augeas-tools"
     unset RUBY_PACKAGES
 else
-    PACKAGES="ruby-bundler $PACKAGES"
+    # Note: pkg-config, libaugeas-dev and augeas-tools are needed to build
+    # ruby-augeas gem
+    PACKAGES="ruby-bundler pkg-config libaugeas-dev augeas-tools $PACKAGES"
 fi
 
 apt-get update

--- a/script/bootstrap-debian
+++ b/script/bootstrap-debian
@@ -15,9 +15,9 @@ elif [ "$CODENAME" = "precise" ]; then
     GEM_BUNDLER=true
     unset RUBY_PACKAGES
 else
-    # Note: pkg-config, libaugeas-dev and augeas-tools are needed to build
-    # ruby-augeas gem
-    PACKAGES="ruby-bundler pkg-config libaugeas-dev augeas-tools $PACKAGES"
+    # Note: Those packages are needed to build ruby-augeas gem
+    AUGEAS_PACKAGES="pkg-config libaugeas-dev augeas-tools"
+    PACKAGES="ruby-bundler $PACKAGES $AUGEAS_PACKAGES"
 fi
 
 apt-get update


### PR DESCRIPTION
This pull request fixes bootstrap on Ubuntu 14.04 - it adds missing package dependencies which are needed to build ruby-augeas gem.

Without those packages bootstrap fails with this error - https://gist.github.com/Kami/a316277fdd67b6d0f439
