### PR TITLE
Use easy_install-2.7, update bin search path

### DIFF
--- a/modules/profile/manifests/auth_backend_pam.pp
+++ b/modules/profile/manifests/auth_backend_pam.pp
@@ -36,7 +36,7 @@ class profile::auth_backend_pam(
 
   exec { 'install auth backend':
     command => "easy_install-2.7 /tmp/st2_auth_backend_pam-${version}-py2.7.egg",
-    path    => '/usr/bin:/usr/sbin:/bin:/sbin',
+    path    => '/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin',
     require => Wget::Fetch["Download auth pam backend"],
     before  => Class['::st2::profile::server'],
   }

--- a/modules/profile/manifests/enterprise_auth_backend_ldap.pp
+++ b/modules/profile/manifests/enterprise_auth_backend_ldap.pp
@@ -38,7 +38,7 @@ class profile::enterprise_auth_backend_ldap(
     }
   
     exec { 'install auth backend':
-      command => "easy_install /tmp/st2_enterprise_auth_backend_ldap-${version}-py2.7.egg",
+      command => "easy_install-2.7 /tmp/st2_enterprise_auth_backend_ldap-${version}-py2.7.egg",
       path    => '/usr/bin:/usr/sbin:/bin:/sbin',
       require => Wget::Fetch["Download enterprise auth ldap backend"]
     }

--- a/modules/profile/manifests/enterprise_auth_backend_ldap.pp
+++ b/modules/profile/manifests/enterprise_auth_backend_ldap.pp
@@ -39,7 +39,7 @@ class profile::enterprise_auth_backend_ldap(
   
     exec { 'install auth backend':
       command => "easy_install-2.7 /tmp/st2_enterprise_auth_backend_ldap-${version}-py2.7.egg",
-      path    => '/usr/bin:/usr/sbin:/bin:/sbin',
+      path    => '/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin',
       require => Wget::Fetch["Download enterprise auth ldap backend"]
     }
   }


### PR DESCRIPTION
- Use easy_install-2.7, same as in the pam module
- Update easy_install-2.7 binary search path since it's located in /usr/local/bin on Ubuntu

``` bash
    root@st2enterprise:/home/vagrant# which easy_install-2.7
    /usr/local/bin/easy_install-2.7
```

Without this change it fails with:

``` bash
Error: Could not find command 'easy_install'
Error: /Stage[main]/Profile::Enterprise_auth_backend_ldap/Exec[install auth backend]/returns: change from notrun to 0 failed: Could not find command 'easy_install'
```
