### PR TITLE
Fix name conflict so you can install both auth backends on a single server

### DIFF
--- a/modules/profile/manifests/auth_backend_pam.pp
+++ b/modules/profile/manifests/auth_backend_pam.pp
@@ -34,7 +34,7 @@ class profile::auth_backend_pam(
     destination => "/tmp/st2_auth_backend_pam-${version}-py2.7.egg"
   }
 
-  exec { 'install auth backend':
+  exec { 'install pam auth backend':
     command => "easy_install-2.7 /tmp/st2_auth_backend_pam-${version}-py2.7.egg",
     path    => '/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin',
     require => Wget::Fetch["Download auth pam backend"],

--- a/modules/profile/manifests/enterprise_auth_backend_ldap.pp
+++ b/modules/profile/manifests/enterprise_auth_backend_ldap.pp
@@ -36,8 +36,8 @@ class profile::enterprise_auth_backend_ldap(
       cache_dir   => '/var/cache/wget',
       destination => "/tmp/st2_enterprise_auth_backend_ldap-${version}-py2.7.egg"
     }
-  
-    exec { 'install auth backend':
+
+    exec { 'install enterprise ldap auth backend':
       command => "easy_install-2.7 /tmp/st2_enterprise_auth_backend_ldap-${version}-py2.7.egg",
       path    => '/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin',
       require => Wget::Fetch["Download enterprise auth ldap backend"]


### PR DESCRIPTION
Before this change there was a conflict which prevented you from being able to install both auth backends on the same server.

``` bash
Error: Evaluation Error: Error while evaluating a Resource Statement, Duplicate declaration: Exec[install auth backend] is already declared in file /opt/puppet/environments/current_working_directory/modules/profile/manifests/enterprise_auth_backend_ldap.pp:40; cannot redeclare at /opt/puppet/environments/current_working_directory/modules/profile/manifests/auth_backend_pam.pp:37 at /opt/puppet/environments/current_working_directory/modules/profile/manifests/auth_backend_pam.pp:37:3 on node st2enterprise.stackstorm.net
```
