### PR TITLE
ensure > 7.x syntax for config

### DIFF
--- a/modules/profile/manifests/rsyslog.pp
+++ b/modules/profile/manifests/rsyslog.pp
@@ -28,6 +28,29 @@ class profile::rsyslog {
     notify => Service['rsyslog']
   }
 
+  # A few emerg data points are managed in a template, that is
+  # controlled via a fact.
+  # https://github.com/saz/puppet-rsyslog/blob/master/lib/facter/rsyslog_version.rb
+  # Because this is a masterless installation of Puppet, we do not have
+  # PluginSync available to us, so we need to manually mock in the
+  # necessary changes that are affecting startup.
+
+  # Template: https://github.com/saz/puppet-rsyslog/blob/master/templates/rsyslog.conf.erb#L72
+  file_line { 'rsync global emergency logging for > 7.x':
+    path   => '/etc/rsyslog.conf',
+    match  => '^\*\.emerg',
+    line   => '*. emerg     :omusrmsg:*',
+    notify => Service['rsyslog'],
+  }
+
+  # Template: https://github.com/saz/puppet-rsyslog/blob/1060bb12493b46239250619688d7e3cbd7212143/templates/client/local.conf.erb#L87
+  file_line { 'rsync local client emergency logging for > 7.x':
+    path   => '/etc/rsyslog.d/client.conf',
+    match  => '^\*\.emerg',
+    line   => '*. emerg     :omusrmsg:*',
+    notify => Service['rsyslog'],
+  }
+
   # Ensure latest version of rsyslogd is available for RHEL 6 systems
   if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '6' {
     wget::fetch { 'rsyslogd repo':

--- a/modules/profile/manifests/rsyslog.pp
+++ b/modules/profile/manifests/rsyslog.pp
@@ -39,7 +39,7 @@ class profile::rsyslog {
   file_line { 'rsync global emergency logging for > 7.x':
     path   => '/etc/rsyslog.conf',
     match  => '^\*\.emerg',
-    line   => '*. emerg     :omusrmsg:*',
+    line   => '*.emerg     :omusrmsg:*',
     notify => Service['rsyslog'],
   }
 
@@ -47,7 +47,7 @@ class profile::rsyslog {
   file_line { 'rsync local client emergency logging for > 7.x':
     path   => '/etc/rsyslog.d/client.conf',
     match  => '^\*\.emerg',
-    line   => '*. emerg     :omusrmsg:*',
+    line   => '*.emerg     :omusrmsg:*',
     notify => Service['rsyslog'],
   }
 


### PR DESCRIPTION
Ensure rsyslog settings work for newer version of software.

Some of the config values are explicitly for older clients, and rely on an unsupported mode for us to properly get the needed values.
