### PR TITLE
remove fixed UID for 'root_cli'

### DIFF
--- a/modules/profile/manifests/st2server.pp
+++ b/modules/profile/manifests/st2server.pp
@@ -31,8 +31,6 @@ class profile::st2server {
   $_enterprise_token = hiera('st2enterprise::token', undef)
   $_root_cli_username = 'root_cli'
   $_root_cli_password = fqdn_rand_string(32)
-  $_root_cli_uid = 2000
-  $_root_cli_gid = 2000
 
   $_init_type = $::st2::params::init_type
 
@@ -249,8 +247,6 @@ class profile::st2server {
   # this installer will pop up in.
 
   users { $_root_cli_username:
-    uid        => $_root_cli_uid,
-    gid        => $_root_cli_gid,
     shell      => '/bin/false',
     password   => $_root_cli_password,
     managehome => false,


### PR DESCRIPTION
This PR removes the fixed UID for the `root_cli` user, as it really isn't necessary. This is an old assumption that we have since fixed in other ways.

So, out with the old. :fire:
