### PR TITLE
Update to st2 build 206

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -5,8 +5,7 @@ classes:
 rsyslog::client::log_local: true
 
 sudo::purge: false
-st2::version: 0.14dev
-st2::revision: 206
+
 st2::autoupdate: false
 st2::packs:
   hubot:

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -6,7 +6,7 @@ rsyslog::client::log_local: true
 
 sudo::purge: false
 st2::version: 0.14dev
-st2::revision: 189
+st2::revision: 206
 st2::autoupdate: false
 st2::packs:
   hubot:

--- a/hieradata/role/st2.yaml
+++ b/hieradata/role/st2.yaml
@@ -6,7 +6,7 @@ npm::proxy: false
 puppet::masterless::cron: disable
 
 st2::version: 0.14dev
-st2::revision: 194
+st2::revision: 206
 st2::autoupdate: false
 st2::mistral_git_branch: st2-1.1.0
 


### PR DESCRIPTION
Looks like the same attribute is defined in two places.

``` bash
kami /w/stackstorm/st2workroom (git:update_to_latest_st2_package)$ ag "st2::revision"
hieradata/role/st2.yaml
9:st2::revision: 194

hieradata/common.yaml
9:st2::revision: 189
```

I assume st2.yaml has precedence. Should we get rid of it from one place, or not?
