### PR TITLE
Make sure default port for LDAP backend is an int

### DIFF
--- a/modules/profile/manifests/enterprise_auth_backend_ldap.pp
+++ b/modules/profile/manifests/enterprise_auth_backend_ldap.pp
@@ -30,7 +30,7 @@ class profile::enterprise_auth_backend_ldap(
 
   $_enterprise_token = hiera('st2enterprise::token', undef)
   $_ldap_host = hiera('st2::ldap::host', undef)
-  $_ldap_port = hiera('st2::ldap::port', '389')
+  $_ldap_port = hiera('st2::ldap::port', 389)
   $_ldap_use_ssl = hiera('st2::ldap::use_ssl', false)
   $_ldap_use_tls = hiera('st2::ldap::use_tls', false)
   $_users_ou = hiera('st2::ldap::base_dn', undef)


### PR DESCRIPTION
I also convert it into an int in the actual LDAP backend, but just in case.
