### PR TITLE
Specifying python 2.7 in the Installer venv

### DIFF
--- a/modules/profile/manifests/st2server.pp
+++ b/modules/profile/manifests/st2server.pp
@@ -846,7 +846,7 @@ class profile::st2server {
 
   python::virtualenv { $_st2installer_root:
     ensure       => present,
-    version      => 'system',
+    version      => '2.7',
     systempkgs   => false,
     venv_dir     => "${_st2installer_root}/.venv",
     cwd          => $_st2installer_root,


### PR DESCRIPTION
Is there any possible drawback of doing this? With “system” things are broken on CentOS/RHEL 6, because Python 2.6 is the system version there.
