### PR TITLE
limit python change for st2installer to RHEL 6 only

### DIFF
--- a/modules/profile/manifests/st2server.pp
+++ b/modules/profile/manifests/st2server.pp
@@ -844,9 +844,14 @@ class profile::st2server {
     notify   => Service['st2installer'],
   }
 
+  if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '6' {
+    $_st2installer_python_ver = '2.7'
+  } else {
+    $_st2installer_python_ver = 'system'
+  }
   python::virtualenv { $_st2installer_root:
     ensure       => present,
-    version      => '2.7',
+    version      => $_st2installer_python_ver,
     systempkgs   => false,
     venv_dir     => "${_st2installer_root}/.venv",
     cwd          => $_st2installer_root,


### PR DESCRIPTION
This PR adjusts #233 to only apply to RHEL 6 hosts, where it is needed. Otherwise, use the defaults.
