### PR TITLE
Fail fast with RedHat builds

### DIFF
--- a/script/bootstrap-redhat
+++ b/script/bootstrap-redhat
@@ -1,4 +1,6 @@
 #!/usr/bin/env sh
+set -e
+
 DIR=$( dirname "$(readlink -f "$0")" )
 . $DIR/shared-functions
 


### PR DESCRIPTION
This PR adds `set -e` to the redhat bootstrap, allowing it to fail fast in the event of an issue.
