### PR TITLE
Change docker dm_basesize to 20g

### DIFF
--- a/modules/profile/manifests/docker.pp
+++ b/modules/profile/manifests/docker.pp
@@ -1,6 +1,8 @@
 class profile::docker {
   $_compose_version = hiera('docker-compose::version', '1.4.0')
-  include ::docker
+  class { '::docker':
+    dm_basesize => '20G',
+  }
 
   $_url = 'https://github.com/docker/compose/releases/download/1.4.0/docker-compose-`uname -s`-`uname -m`'
   $_output_file = '/usr/bin/docker-compose'


### PR DESCRIPTION
The default `dm_basesize` was recently changed from `10G` to `100G`. This is causing timeouts with docker starting as the `mkfs.ext4` command times out in 90 seconds because `systemd`.

As recommended in the below issue, we are changing the default to `20G` 

https://github.com/docker/docker/issues/16653
