### PR TITLE
Move dm_basesize parameter to 'extra_patterns'

### DIFF
--- a/modules/profile/manifests/docker.pp
+++ b/modules/profile/manifests/docker.pp
@@ -1,7 +1,8 @@
 class profile::docker {
   $_compose_version = hiera('docker-compose::version', '1.4.0')
+
   class { '::docker':
-    dm_basesize => '20G',
+    extra_parameters => ['--storage-opt dm.basesize=20G'],
   }
 
   $_url = 'https://github.com/docker/compose/releases/download/1.4.0/docker-compose-`uname -s`-`uname -m`'


### PR DESCRIPTION
The parameter at top-level (`dm_basesize`) does not propagate to the RHEL 7 config. This PR moves the needed attribute to `extra_parameters`. 

/cc #251 
