### PR TITLE
Fix docker dm basesize

### DIFF
--- a/modules/profile/manifests/docker.pp
+++ b/modules/profile/manifests/docker.pp
@@ -2,7 +2,7 @@ class profile::docker {
   $_compose_version = hiera('docker-compose::version', '1.4.0')
 
   class { '::docker':
-    extra_parameters => ['--storage-opt dm.basesize=20G'],
+    extra_parameters => '--storage-opt dm.basesize=20G',
   }
 
   $_url = 'https://github.com/docker/compose/releases/download/1.4.0/docker-compose-`uname -s`-`uname -m`'

--- a/modules/profile/manifests/mongodb.pp
+++ b/modules/profile/manifests/mongodb.pp
@@ -1,6 +1,6 @@
 class profile::mongodb {
-  include ::docker
   $_version = hiera('mongodb::version', '2.4.14')
+  include ::profile::docker
 
   if $::osfamily == 'Debian' {
     # Needed to build mongoengine

--- a/modules/profile/manifests/rabbitmq.pp
+++ b/modules/profile/manifests/rabbitmq.pp
@@ -1,6 +1,6 @@
 class profile::rabbitmq {
   $_version = hiera('rabbitmq::version', '3.5.4')
-  include ::docker
+  include ::profile::docker
 
   docker::image { 'rabbitmq':
     ensure => present,


### PR DESCRIPTION
This PR _actually_ should do what I am asking, because the active code-paths did not include the `profile::docker`. To fix this, includes for `rabbitmq` and `mongodb` are now using the central docker profile.

/cc #251 #252 
