### PR TITLE
Update docker.pp

### DIFF
--- a/modules/profile/manifests/docker.pp
+++ b/modules/profile/manifests/docker.pp
@@ -1,9 +1,7 @@
 class profile::docker {
   $_compose_version = hiera('docker-compose::version', '1.4.0')
 
-  class { '::docker':
-    extra_parameters => ['--storage-opt dm.basesize=20G'],
-  }
+  class { '::docker': }
 
   $_url = 'https://github.com/docker/compose/releases/download/1.4.0/docker-compose-`uname -s`-`uname -m`'
   $_output_file = '/usr/bin/docker-compose'


### PR DESCRIPTION
This PR reverts #254 because it breaks RHEL 6. Will look into another method to get CI to pass properly.
