### PR TITLE
disable timeout locally for systemd + docker

### DIFF
--- a/modules/profile/manifests/mongodb.pp
+++ b/modules/profile/manifests/mongodb.pp
@@ -1,5 +1,5 @@
 class profile::mongodb {
-  include ::docker
+  include ::profile::docker
   $_version = hiera('mongodb::version', '2.4.14')
 
   if $::osfamily == 'Debian' {

--- a/modules/profile/manifests/rabbitmq.pp
+++ b/modules/profile/manifests/rabbitmq.pp
@@ -1,6 +1,6 @@
 class profile::rabbitmq {
   $_version = hiera('rabbitmq::version', '3.5.4')
-  include ::docker
+  include ::profile::docker
 
   docker::image { 'rabbitmq':
     ensure => present,


### PR DESCRIPTION
This commit ensures that the docker service can take as long
as it so desires to startup. This bypasses the issues experienced
as a result of https://github.com/docker/docker/issues/16653,
and should still ensure that RHEL 6 hosts are not affected by the
`dm.basesize` option change.
