### PR TITLE
use system service vs unit to control startup

### DIFF
--- a/modules/profile/manifests/docker.pp
+++ b/modules/profile/manifests/docker.pp
@@ -35,8 +35,8 @@ class profile::docker {
   if $_init_type == 'systemd' {
     $_docker_override_dir = '/etc/systemd/system/docker.service.d'
     $_docker_override = @("EOF")
-    [Unit]
-    TimeoutSec=0
+    [Service]
+    TimeoutStartSec=0
     | EOF
 
     file { $_docker_override_dir:


### PR DESCRIPTION
I will readily admit... I am still learning `systemd` and understanding how and where various flags go. This moves from `TimeoutSec` value from the `[Unit]` section to the `[Service]` section. 

/cc #257 #256 
