### PR TITLE
Ignore `git pull` error during puppet-apply

### DIFF
--- a/script/puppet-apply
+++ b/script/puppet-apply
@@ -46,7 +46,7 @@ fi
 
 # Do not attempt to upload from upstream git
 if [ -z "$DISABLE_GIT" ]; then
-    git pull origin -q $GIT_DEBUG_ARGS
+    git pull origin -q $GIT_DEBUG_ARGS || true
 fi
 
 ## Run any pre-flight commands


### PR DESCRIPTION
When local HEAD is already matches the HEAD of the remote branch, the line throws an error

```
There are no candidates for merging among the refs that you just fetched.
Generally this means that you provided a wildcard refspec which had no
matches on the remote end.
```

which is basically a fancy way of saying there's nothing more to pull.
