### PR TITLE
Refactor Hubot dependencies

### DIFF
--- a/modules/st2migrations/manifests/definition.pp
+++ b/modules/st2migrations/manifests/definition.pp
@@ -1,0 +1,39 @@
+# Boilerplate template for st2migrations
+define st2migrations::definition(
+  $id,
+  $version,
+  $script,
+) {
+  $_rundir = $::st2migrations::exec_dir
+  $_fact = "st2migration_${id}_${name}"
+
+  $_default_notify = Exec["${_rundir}/${name}"]
+
+  if $::facts[$_fact] != $version {
+    file { "${_rundir}/${name}":
+      ensure  => file,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0755',
+      content => $script,
+      notify  => [
+        $_default_notify,
+      ],
+    }
+    exec { "${_rundir}/${name}":
+      path    => [
+        '/usr/bin',
+        '/usr/sbin',
+        '/bin',
+        '/sbin',
+      ],
+      before  => [
+        Facter::Fact[$_fact],
+      ],
+    }
+
+    facter::fact { $_fact:
+      value => $version,
+    }
+  }
+}

--- a/modules/st2migrations/manifests/id_2015111901_remove_hubot_dependencies_from_answers.pp
+++ b/modules/st2migrations/manifests/id_2015111901_remove_hubot_dependencies_from_answers.pp
@@ -17,11 +17,12 @@ class st2migrations::id_2015111901_remove_hubot_dependencies_from_answers {
   if [ -f \$FILE ]; then
     cat \$FILE | python -c '
       import json,sys;
-      obj = json.load(sys.stdin)
-      obj.pop("hubot::dependencies", None)
-      print json.dumps(obj)' > \$FILE.new
+      obj = json.load(sys.stdin);
+      obj.pop("hubot::dependencies", None);
+      print json.dumps(obj);' > \$FILE.new
 
     mv \$FILE.new \$FILE
+  fi
   | EOT
 
   ::st2migrations::definition { 'remove_hubot_dependencies_from_answers':

--- a/modules/st2migrations/manifests/id_2015111901_remove_hubot_dependencies_from_answers.pp
+++ b/modules/st2migrations/manifests/id_2015111901_remove_hubot_dependencies_from_answers.pp
@@ -1,0 +1,32 @@
+# Migration: Remove Hubot Dependencies from Answers
+#
+# The current mechanism to manage hubot dependencies via package.json
+# is proving to be non-ideal. This migration accompanies changes in
+# ::profile::hubot that instead moves responsibility of managing NPM
+# from the hubot repo to Puppet
+#
+# To make this change, any users that have an answers file generated
+# by st2installer before this date and the change made in
+# https://github.com/StackStorm/st2installer/pull/82, this migration
+# will take care of cleanup for them.
+#
+class st2migrations::id_2015111901_remove_hubot_dependencies_from_answers {
+  $_shell_script = @("EOT"/)
+  FILE=${::settings::confdir}/hieradata/answers.json
+
+  if [ -f \$FILE ]; then
+    cat \$FILE | python -c '
+      import json,sys;
+      obj = json.load(sys.stdin)
+      obj.pop("hubot::dependencies", None)
+      print json.dumps(obj)' > \$FILE.new
+
+    mv \$FILE.new \$FILE
+  | EOT
+
+  ::st2migrations::definition { 'remove_hubot_dependencies_from_answers':
+    id      => '2015111901',
+    version => '1',
+    script  => $_shell_script,
+  }
+}

--- a/modules/st2migrations/manifests/init.pp
+++ b/modules/st2migrations/manifests/init.pp
@@ -12,4 +12,5 @@ class st2migrations (
   include ::st2migrations::id_2015092102_disable_st2services_for_upgrade
   include ::st2migrations::id_2015092101_refresh_mistral_venv
   include ::st2migrations::id_2015092201_disable_mistral_nginx
+  include ::st2migrations::id_2015111901_remove_hubot_dependencies_from_answers
 }


### PR DESCRIPTION
This PR updates the mechanism how Hubot dependencies are managed on a system, removing them from `package.json` to being directly managed by Puppet. This gives us several benefits:
- Clear responsibility of ownership with module installation. Puppet and NPM fought prior to this
- Fine-grained control of versions on disk, on a per-module basis.

/cc https://github.com/StackStorm/st2installer/pull/82
