### PR TITLE
Hubot ordering fixes

### DIFF
--- a/modules/profile/manifests/hubot.pp
+++ b/modules/profile/manifests/hubot.pp
@@ -99,6 +99,7 @@ class profile::hubot(
         target => $_hubot_bin_dir,
         user   => $_hubot_user,
         before => Facter::Fact["hubot_dependency_${_name}"],
+        notify => Service['hubot'],
       }
       facter::fact { "hubot_dependency_${_name}":
         value => $_value,

--- a/modules/st2migrations/manifests/id_2015111901_remove_hubot_dependencies_from_answers.pp
+++ b/modules/st2migrations/manifests/id_2015111901_remove_hubot_dependencies_from_answers.pp
@@ -29,5 +29,6 @@ class st2migrations::id_2015111901_remove_hubot_dependencies_from_answers {
     id      => '2015111901',
     version => '1',
     script  => $_shell_script,
+    before  => Class['::profile::st2server'],
   }
 }


### PR DESCRIPTION
This PR accompanies #263, where the Hubot service needs to be notified that libraries have been updated. Otherwise, Hubot may startup in a state where not every library has been installed.

Likewise, the migration to remove existing dependencies also is ordered before the St2 profile is installed and configured.
