### PR TITLE
Add proxy settings to Docker

### DIFF
--- a/modules/profile/manifests/docker.pp
+++ b/modules/profile/manifests/docker.pp
@@ -2,8 +2,11 @@ class profile::docker {
   include ::st2::params
   $_init_type = $::st2::params::init_type
   $_compose_version = hiera('docker-compose::version', '1.4.0')
+  $_http_proxy = hiera('system::http_proxy', undef)
 
-  class { '::docker': }
+  class { '::docker':
+    proxy => $_http_proxy,
+  }
 
   $_url = 'https://github.com/docker/compose/releases/download/1.4.0/docker-compose-`uname -s`-`uname -m`'
   $_output_file = '/usr/bin/docker-compose'


### PR DESCRIPTION
This PR adds proxy support to Docker by passing through the entered `system::http_proxy` setting.

Requested by @mosesschwartz in #stackstorm-community
