### PR TITLE
enabling proxy for apt services

### DIFF
--- a/hieradata/osfamily/Debian.yaml
+++ b/hieradata/osfamily/Debian.yaml
@@ -1,4 +1,7 @@
 ---
+classes:
+  - 'profile::debian'
+
 system::packages:
   - "bc"
   - "whois"

--- a/modules/profile/manifests/debian.pp
+++ b/modules/profile/manifests/debian.pp
@@ -9,11 +9,13 @@ class profile::debian {
   ## This section parses the proxy and prepares it for usage in
   ## the puppetlabs/puppetlabs-apt module.
   if $_http_proxy {
-    $_parse_url = @("EOF"/)
+    $_parser = @("EOF"/)
     require 'uri'
     uri = URI.parse(@_http_proxy)
     [uri.host, uri.port]
     | EOF
+
+    $_parse_url = inline_template('<%= @_parser %>')
 
     $_proxy = {
       ensure => file,

--- a/modules/profile/manifests/debian.pp
+++ b/modules/profile/manifests/debian.pp
@@ -1,0 +1,31 @@
+class profile::debian {
+  $_http_proxy = hiera('system::http_proxy', undef)
+
+  $_is_https = $_http_proxy ? {
+    /^https/ => true,
+    default  => false,
+  }
+
+  ## This section parses the proxy and prepares it for usage in
+  ## the puppetlabs/puppetlabs-apt module.
+  if $_http_proxy {
+    $_parse_url = @("EOF"/)
+    require 'uri'
+    uri = URI.parse(@_http_proxy)
+    [uri.host, uri.port]
+    | EOF
+
+    $_proxy = {
+      ensure => file,
+      host   => $_parse_url[0],
+      port   => $_parse_url[1],
+      https  => $_is_https,
+    }
+  } else {
+    $_proxy = undef
+  }
+
+  class { '::apt':
+    proxy => $_proxy,
+  }
+}


### PR DESCRIPTION
This PR ensures that users who set HTTP_PROXY settings before installer are also enabled for Apt package repository.

Fixes #261 
