### PR TITLE
wrong variable on file mount for CA certificate

### DIFF
--- a/modules/profile/manifests/st2server.pp
+++ b/modules/profile/manifests/st2server.pp
@@ -611,7 +611,7 @@ class profile::st2server {
     ## of annoying issues related to self-signed or trusted
     ca_cert::ca { 'stackstorm-ca':
       ensure => 'trusted',
-      source => "file://${_ca_cer}",
+      source => "file://${_ca_cert}",
     }
   }
 


### PR DESCRIPTION
This PR fixes #272, as there was a small typo in the variable name used. Tested and fixed.
