### PR TITLE
do not install hubot if using BYOBot

### DIFF
--- a/modules/profile/manifests/hubot.pp
+++ b/modules/profile/manifests/hubot.pp
@@ -7,6 +7,6 @@ class profile::hubot{
   } elsif not $_hubot_docker and $_adapter_defined {
     include ::profile::hubot::legacy
   } else {
-    notify { 'ST2 Hubot is not configured for this host. Please see installation instructions': }
+    notify { 'ST2 Hubot is not configured for this host. Please see installation instructions if this is in error': }
   }
 }

--- a/modules/profile/manifests/hubot.pp
+++ b/modules/profile/manifests/hubot.pp
@@ -1,6 +1,6 @@
 class profile::hubot{
   $_hubot_docker = hiera('hubot::docker', false)
-  $_adapter_defined = hiera('hubot::adapter' undef)
+  $_adapter_defined = hiera('hubot::adapter', undef)
 
   if $_hubot_docker and $_adapter_defined {
     include ::profile::hubot::docker

--- a/modules/profile/manifests/hubot.pp
+++ b/modules/profile/manifests/hubot.pp
@@ -7,6 +7,6 @@ class profile::hubot{
   } elsif not $_hubot_docker and $_adapter_defined {
     include ::profile::hubot::legacy
   } else {
-    notify { 'Hubot has not been fully configured on this host yet. Please see installation instructions': }
+    notify { 'ST2 Hubot is not configured for this host. Please see installation instructions': }
   }
 }

--- a/modules/profile/manifests/hubot.pp
+++ b/modules/profile/manifests/hubot.pp
@@ -1,9 +1,12 @@
 class profile::hubot{
   $_hubot_docker = hiera('hubot::docker', false)
+  $_adapter_defined = hiera('hubot::adapter' undef)
 
-  if $_hubot_docker {
+  if $_hubot_docker and $_adapter_defined {
     include ::profile::hubot::docker
-  } else {
+  } elsif not $_hubot_docker and $_adapter_defined {
     include ::profile::hubot::legacy
+  } else {
+    notify { 'Hubot has not been fully configured on this host yet. Please see installation instructions': }
   }
 }


### PR DESCRIPTION
This PR ensures that Hubot is _not_ installed if it is not needed. This is done by checking for the existence of the `hubot::adapter` hiera data. This is populated by https://github.com/StackStorm/st2installer/blob/master/st2installer/controllers/root.py#L251 and friends.

If the user choose BYOBot, then this ensures that hubot is only installed once it's requested.

/cc https://github.com/StackStorm/st2/issues/2285
