### PR TITLE
Adding additional RHEL baseline packages

### DIFF
--- a/script/bootstrap-redhat
+++ b/script/bootstrap-redhat
@@ -16,7 +16,7 @@ if [ $MAJORVER = "6" ]; then
     SCL="centos-release-SCL"
 elif [ $MAJORVER = "7" ]; then
     EPEL="https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
-    PACKAGES="ruby ruby-devel rubygem-bundler unzip curl git-core augeas augeas-devel gperftools-libs"
+    PACKAGES="ruby ruby-devel rubygem-bundler unzip curl git-core augeas augeas-devel gperftools-libs bind-utils net-tools"
     CR=true
 fi
 


### PR DESCRIPTION
Thanks to the help of one of our users (h/t Mr Crawford. :tophat:), we learned that two additional packages are needed when bootstrapping from the most _minimal_ of RHEL/CentOS installations.

These packages allow for `facter` to be able to source the `ipaddress` and `hostname` facts correctly.
