### PR TITLE
docker data container require image

### DIFF
--- a/modules/profile/manifests/mongodb.pp
+++ b/modules/profile/manifests/mongodb.pp
@@ -24,6 +24,7 @@ class profile::mongodb {
       '/usr/sbin',
     ],
     refreshonly => true,
+    require     => Docker::Image['mongo']
   }
 
   docker::run { 'mongo':


### PR DESCRIPTION
This resolves a conflict between the image `mongo:latest` that is downloaded by the data container exec, and the version that is required by the mongo container.
