### PR TITLE
Lock installer version

### DIFF
--- a/hieradata/role/st2.yaml
+++ b/hieradata/role/st2.yaml
@@ -9,6 +9,7 @@ st2::version: 1.2.0
 st2::revision: 8
 st2::autoupdate: false
 st2::mistral_git_branch: st2-1.2.0
+st2::installer_branch: v0.1.0
 
 profile::enterprise_auth_backend::version: 0.1.0
 hubot::external_scripts:


### PR DESCRIPTION
To have installer versioning we have to lock it in the workroom st2.yaml along with the st2 version.

Untested, don’t merge for now.
