### PR TITLE
Fix "-r" option

### DIFF
--- a/script/bootstrap-st2
+++ b/script/bootstrap-st2
@@ -105,6 +105,10 @@ if [ -n "$REF" ]; then
         printf "ERROR: Cannot checkout ref: ${REF}. Check if ref (SHA or tag) is valid."
         exit 3
     fi
+
+    # Set ENV to current working directory so the selected revision will also be
+    # used
+    export ENV=current_working_directory
 fi
 
 # Ability to disable hubot, drop to long-term setting for installer.


### PR DESCRIPTION
Now if "-r" option is specified we also set ENV environment variable to `current_working_directory` so the checked out changes (revision) are actually used.

P.S. As noted on Slack, this is a very simple solution I could come up with first which works (that's basically how I / we have been testing changes manually before this option).

Resolves #321.

Tested with:

``` bash
curl -o install.sh https://raw.githubusercontent.com/StackStorm/st2workroom/ce8dbb424bfbe58224fde44217eb0dd4ade1aa25/script/bootstrap-st2 # we want to use bootstrap-st2 from this branch of course which includes the fix
DEBUG=1 bash install.sh -r test_rev_branch # created a test branch which introduces a failure
...
1901_remove_hubot_dependencies_from_answers] will propagate my refresh event
Debug: Exec[test-fail](provider=posix): Executing 'echo "fail" ; exit 1'
Debug: Executing: 'echo "fail" ; exit 1'
Notice: /Stage[main]/Profile::St2server/Exec[test-fail]/returns: fail
Error: echo "fail" ; exit 1 returned 1 instead of one of [0]
Error: /Stage[main]/Profile::St2server/Exec[test-fail]/returns: change from notrun to 0 failed: echo "fail" ; exit 1 returned 1 instead of one of [0]
Notice: /Stage[main]/Profile::St2server/File[/var/sockets]/ensure: created
....
```
