### PR TITLE
Specify min pip version

### DIFF
--- a/modules/profile/manifests/python.pp
+++ b/modules/profile/manifests/python.pp
@@ -2,12 +2,12 @@ class profile::python {
   include ::st2::profile::python
   include ::st2::profile::repos
 
-  file { '/etc/facter/facts.d/pip_upgrade_201601021.txt':
+  file { '/etc/facter/facts.d/pip_upgrade_201601025.txt':
     ensure  => file,
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    content => 'pip_upgrade_201601021=true',
+    content => 'pip_upgrade_201601025=true',
     notify  => Exec['update-pip'],
   }
 

--- a/modules/profile/manifests/python.pp
+++ b/modules/profile/manifests/python.pp
@@ -12,7 +12,7 @@ class profile::python {
   }
 
   exec { 'update-pip':
-    command     => 'pip install --log /tmp/pip.log -U "pip<8.0.0"',
+    command     => 'pip install --log /tmp/pip.log -U "pip>=7.1.2,<8.0.0"',
     path        => '/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
     require     => Class['::st2::profile::repos'],
   }


### PR DESCRIPTION
This fixes regression introduced by #318.

We only specified a max version and not a min one which means any pip version prior 8.0.0 would satisfy that requirement.

This means that on the systems which ship old pip versions things would break since pip < 6.1 doesn't include all the functionality we need.

Caught by @dzimine.
