### PR TITLE
Fix puppet convergence issue (bump installer)

### DIFF
--- a/hieradata/role/st2.yaml
+++ b/hieradata/role/st2.yaml
@@ -9,7 +9,7 @@ st2::version: 1.2.0
 st2::revision: 8
 st2::autoupdate: false
 st2::mistral_git_branch: st2-1.2.0
-st2::installer_branch: v0.1.1
+st2::installer_branch: v0.1.2
 
 profile::enterprise_auth_backend::version: 0.1.0
 hubot::external_scripts:


### PR DESCRIPTION
This bumps the installer to a version which fixes the convergence issue - https://github.com/StackStorm/st2installer/pull/100

Keep in mind that this doesn't identify nor fix the root cause. We spent a lot of time on it, but we were unable to identify the root cause.

With this change puppet now runs twice and the things which only converge on second run usually tend to be:
- RBAC role assignments
- root_cli user st2 config file (/root/st2/config.ini)
- PostgreSQL password
- Pack file permissions
- Some nginx vhost stuff
- datastore values set during the installer
- etc

If someone ever identifies the root cause and fixes it (that would be great), please feel free to get rid of this workaround / hack.
