### PR TITLE
Make sure nginx is actually restarted on refresh events

### DIFF
--- a/modules/profile/manifests/st2server.pp
+++ b/modules/profile/manifests/st2server.pp
@@ -211,7 +211,7 @@ class profile::st2server {
 
   class { '::nginx':
     package_name      => "${_nginx_package}",
-    service_restart   => '/etc/init.d/nginx configtest',
+    service_restart   => '/etc/init.d/nginx restart',
     configtest_enable => $_nginx_configtest,
   }
 


### PR DESCRIPTION
I noticed this bug while testing installer changes - it looked like installer branch / revision was correctly checked out but the installer still used incorrect revision.

I believe the issue is related to initial puppet run not restarting nginx, but I could be wrong.

The reason why I suspect this is because when I manually test the changes (manually cloned / checked out branch, restarted nginx and st2installer uwsgi process) it works fine.
