### PR TITLE
Don't restart st2installer uwsgi app during the installer run

### DIFF
--- a/modules/adapter/manifests/st2_uwsgi_init.pp
+++ b/modules/adapter/manifests/st2_uwsgi_init.pp
@@ -7,6 +7,7 @@
 #
 define adapter::st2_uwsgi_init (
   $subsystem = $name,
+  $enable_restart = true,
 ) {
   include ::st2::params
   include ::profile::uwsgi
@@ -81,4 +82,10 @@ define adapter::st2_uwsgi_init (
   # Subscribe to Uwsgi Apps of the same name.
   File[$_init_file] ~> Service[$_subsystem]
   Ini_setting<| tag == 'st2::config' |> ~> Service[$_subsystem]
+
+  if $enable_restart == false {
+    Service[$_subsystem] {
+      restart => 'exit 0',
+    }
+  }
 }

--- a/modules/adapter/manifests/st2_uwsgi_init.pp
+++ b/modules/adapter/manifests/st2_uwsgi_init.pp
@@ -85,7 +85,7 @@ define adapter::st2_uwsgi_init (
 
   if $enable_restart == false {
     Service[$_subsystem] {
-      restart => 'exit 0',
+      restart => '/bin/true'
     }
   }
 }

--- a/modules/adapter/manifests/st2_uwsgi_init.pp
+++ b/modules/adapter/manifests/st2_uwsgi_init.pp
@@ -6,7 +6,7 @@
 #  keep that script still usable.
 #
 define adapter::st2_uwsgi_init (
-  $subsystem = $name,
+  $subsystem      = $name,
   $enable_restart = true,
 ) {
   include ::st2::params

--- a/modules/profile/manifests/st2server.pp
+++ b/modules/profile/manifests/st2server.pp
@@ -218,7 +218,7 @@ class profile::st2server {
   # Ensure that IPTables has access rules to alloww
   # access to StackStorm ports as necessary.
   firewall { '100 allow HTTP/HTTPS/ST2 Access':
-    dport  => ['80', '443', $_st2auth_port, $_st2api_port],
+    dport  => ['80', '443' , $_st2auth_port, $_st2api_port],
     proto  => tcp,
     action => accept,
   }
@@ -967,7 +967,7 @@ class profile::st2server {
   # Note: We don't want to restart st2installer uwsgi app since will break
   # puppet run (it kills the running process) so puppet wont fully converge
 
-  if $_installer_running == true {
+  if $_installer_running {
     $_st2installer_uwsgi_restart = false
   }
   else {

--- a/modules/profile/manifests/st2server.pp
+++ b/modules/profile/manifests/st2server.pp
@@ -218,7 +218,7 @@ class profile::st2server {
   # Ensure that IPTables has access rules to alloww
   # access to StackStorm ports as necessary.
   firewall { '100 allow HTTP/HTTPS/ST2 Access':
-    dport  => ['80', '443' , $_st2auth_port, $_st2api_port],
+    dport  => ['80', '443', $_st2auth_port, $_st2api_port],
     proto  => tcp,
     action => accept,
   }

--- a/modules/profile/manifests/st2server.pp
+++ b/modules/profile/manifests/st2server.pp
@@ -227,7 +227,7 @@ class profile::st2server {
   # ancillary permissions to specific files. The OS in most cases assigns
   # the daemon user to the same named group. Let's roll with it and
   # see how far it gets us.
-  $_nginx_daemon_user = $::nginx::config::daemon_user
+  hort_nginx_daemon_user = $::nginx::config::daemon_user
   $_st2_packs_group = $::st2::params::packs_group_name
 
   # Ensure user belongs to the st2packs group
@@ -962,8 +962,20 @@ class profile::st2server {
   }
 
   ## This creates the init script to start the
-  ## st2installer service via uwsgi
+  ## st3installer service via uwsgi
+
+  # Note: We don't want to restart st2installer uwsgi app since will break
+  # puppet run (it kills the running process) so puppet wont fully converge
+
+  if $_installer_running == true {
+    $_st2installer_uwsgi_restart = false
+  }
+  else {
+    $_st2installer_uwsgi_restart = true
+  }
+
   adapter::st2_uwsgi_init { 'st2installer':
+    enable_restart => $_st2installer_uwsgi_restart,
     require => File['/var/sockets'],
   }
 

--- a/modules/profile/manifests/st2server.pp
+++ b/modules/profile/manifests/st2server.pp
@@ -227,7 +227,7 @@ class profile::st2server {
   # ancillary permissions to specific files. The OS in most cases assigns
   # the daemon user to the same named group. Let's roll with it and
   # see how far it gets us.
-  hort_nginx_daemon_user = $::nginx::config::daemon_user
+  $_nginx_daemon_user = $::nginx::config::daemon_user
   $_st2_packs_group = $::st2::params::packs_group_name
 
   # Ensure user belongs to the st2packs group
@@ -962,7 +962,7 @@ class profile::st2server {
   }
 
   ## This creates the init script to start the
-  ## st3installer service via uwsgi
+  ## st2installer service via uwsgi
 
   # Note: We don't want to restart st2installer uwsgi app since will break
   # puppet run (it kills the running process) so puppet wont fully converge


### PR DESCRIPTION
I have finally been able to track down the root cause for the installer convergence issue.

The problem is that st2installer uwsgi app is restarted during installer puppet run which kills the puppet run process since it doesn't run in the background which means the system doesn't fully converge. From what it looks like, this issue was there since the beginning.

Future improvement would also be to run puprun inside installer in the background, but baby steps.
