### PR TITLE
Add script which runs "bundle exec librarian-puppet package --verbose"

### DIFF
--- a/scripts/bundle-dependencies.sh
+++ b/scripts/bundle-dependencies.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# Script which updates bundled Puppet dependencies in vendor/puppet/cache/*
+# and updates Puppetfile.lock based on the values in Puppetfile
+bundle exec librarian-puppet package --verbose


### PR DESCRIPTION
I think it's easier to run this script then always remembering the command :)

In addition to that, I just recently found out `--verbose` flag. It comes handy since by default, if `Puppetfile` contains invalid version specifier, `bundle exec librarian-puppet package` will silently quit and not produce any error messages which means you won't know things are broken.
