### PR TITLE
Bump st2installer version

### DIFF
--- a/hieradata/role/st2.yaml
+++ b/hieradata/role/st2.yaml
@@ -9,7 +9,7 @@ st2::version: 1.3.0
 st2::revision: 12
 st2::autoupdate: false
 st2::mistral_git_branch: st2-1.3.0
-st2::installer_branch: v0.1.3
+st2::installer_branch: v0.1.4
 
 profile::enterprise_auth_backend::version: 0.1.0
 hubot::external_scripts:


### PR DESCRIPTION
Set the current st2installer version to 0.1.4 (latest) for the Hubot env variables escaping to work properly.
