### PR TITLE
Upgrade check script improvements

### DIFF
--- a/script/upgrade-st2-check
+++ b/script/upgrade-st2-check
@@ -85,8 +85,8 @@ if [ ${INSTALLED_VERSION_REVISION} = ${TO_BE_INSTALLED_VERSION_REVISION} ]; then
     exit 0
 fi
 
-echo "We noticed that the currently installed version ${INSTALLED_VERSION_REVISION} and to be installed version ${TO_BE_INSTALLED_VERSION_REVISION}"
-echo "of StackStorm are different. Version ${TO_BE_INSTALLED_VERSION_REVISION} will overwrite version ${INSTALLED_VERSION_REVISION}. To avoid an"
+echo "We noticed that the currently installed version \"${INSTALLED_VERSION_REVISION}\" and to be installed version \"${TO_BE_INSTALLED_VERSION_REVISION}\""
+echo "of StackStorm are different. Version \"${TO_BE_INSTALLED_VERSION_REVISION}\" will overwrite version \"${INSTALLED_VERSION_REVISION}\". To avoid an"
 echo "unintentional change of version, please follow instructions from https://stackstorm.reamaze.com/kb/installation/pin-installed-stackstorm-version"
 echo "and hit 'n'."
 echo

--- a/script/upgrade-st2-check
+++ b/script/upgrade-st2-check
@@ -32,6 +32,16 @@ is_st2_installed INSTALLED
 
 # If st2 is not installed then exit immediately
 if [ ${INSTALLED} = false ]; then
+    echo "StackStorm is not installed (${TEST_PACKAGE} package not present), skipping upgrade check..."
+    exit 0
+fi
+
+# Additional check, if st2 is not present we assume st2 is not installed and exit immediately
+OUTPUT=$(st2 --version)
+EXIT_CODE=$?
+
+if [ ${EXIT_CODE} -eq 127 ]; then
+    echo "StackStorm is not installed (st2 CLI binary not present), skipping upgrade check..."
     exit 0
 fi
 


### PR DESCRIPTION
This pull request also assumes StackStorm is not installed if `st2` CLI binary is not present on the system and skips upgrade checks.
## Reasoning

One of the users forwarded this message to the support:

> We noticed that the currently installed version and to be installed 
> version 1.3.2.16
> of StackStorm are different. Version 1.3.2.16 will overwrite version . To 
> avoid an
> unintentional change of version, please follow instructions from 
> https://stackstorm.reamaze.com/kb/installation/pin-installed-stackstorm-version
> and hit 'n'.

It looks like "INSTALLED_VERSION_REVISION" variable is for some reason not defined. The most likely reason is that st2client is not installed (due to partial failed installation or similar).
