### PR TITLE
[WIP] [gunicorn] Use 1 "sync" worker type with 1 process and 1 thread for st2api

### DIFF
--- a/modules/adapter/manifests/st2_gunicorn_init.pp
+++ b/modules/adapter/manifests/st2_gunicorn_init.pp
@@ -6,9 +6,10 @@
 #  keep that script still usable.
 #
 define adapter::st2_gunicorn_init (
-  $subsystem = $name,
-  $workers   = 1,
-  $threads   = 1,
+  $subsystem   = $name,
+  $workers     = 1,
+  $threads     = 1,
+  $worker_type = 'sync',
   $socket,
   $user,
   $group,

--- a/modules/adapter/templates/st2_gunicorn_init/init.conf.erb
+++ b/modules/adapter/templates/st2_gunicorn_init/init.conf.erb
@@ -20,6 +20,6 @@ kill timeout 60
 script
     export PYTHONPATH=<%= @_python_pack %>/<%= @_subsystem %>/<%= @_subsystem %>
     gunicorn_pecan <%= @_python_pack %>/<%= @_subsystem %>/gunicorn_config.py \
-      -k eventlet -b unix:<%= @socket %> --threads <%= @threads %> \
+      -k <%= @worker_type %> -b unix:<%= @socket %> --threads <%= @threads %> \
       --workers <%= @workers %> -u <%= @user %> -g <%= @group %>
 end script

--- a/modules/adapter/templates/st2_gunicorn_init/init.service.erb
+++ b/modules/adapter/templates/st2_gunicorn_init/init.service.erb
@@ -6,7 +6,7 @@ After=network.target
 Type=simple
 Environment="PYTHONPATH=<%= @_python_pack %>/<%= @_subsystem %>/<%= @_subsystem %>"
 ExecStart=/bin/gunicorn_pecan <%= @_python_pack %>/<%= @_subsystem %>/gunicorn_config.py \
-      -k eventlet -b unix:<%= @socket %> --threads <%= @threads %> \
+      -k <%= @worker_type %> -b unix:<%= @socket %> --threads <%= @threads %> \
       --workers <%= @workers %> -u <%= @user %> -g <%= @group %>
 TimeoutSec=60
 PrivateTmp=true

--- a/modules/adapter/templates/st2_gunicorn_init/init.sysv.erb
+++ b/modules/adapter/templates/st2_gunicorn_init/init.sysv.erb
@@ -20,7 +20,7 @@ export PATH
 name="<%= @_subsystem %>"
 program="/usr/bin/gunicorn_pecan"
 args="<%= @_python_pack %>/<%= @_subsystem %>/gunicorn_config.py   \
-      -k eventlet -b unix:<%= @socket %> --threads <%= @threads %> \
+      -k <%= @worker_type %> -b unix:<%= @socket %> --threads <%= @threads %> \
       --workers <%= @workers %> -u <%= @user %> -g <%= @group %>   \
       --pid /var/run/$name.pid"
 pidfile="/var/run/$name.pid"

--- a/script/upgrade-st2-check
+++ b/script/upgrade-st2-check
@@ -32,6 +32,16 @@ is_st2_installed INSTALLED
 
 # If st2 is not installed then exit immediately
 if [ ${INSTALLED} = false ]; then
+    echo "StackStorm is not installed (${TEST_PACKAGE} package not present), skipping upgrade check..."
+    exit 0
+fi
+
+# Additional check, if st2 is not present we assume st2 is not installed and exit immediately
+OUTPUT=$(st2 --version)
+EXIT_CODE=$?
+
+if [ ${EXIT_CODE} -eq 127 ]; then
+    echo "StackStorm is not installed (st2 CLI binary not present), skipping upgrade check..."
     exit 0
 fi
 


### PR DESCRIPTION
It turns out that "eventlet" worker type doesn't work well with the code which relies on eventlet monkey patching and performs a lot of I/O. Performance and throughput is very bad (it simply looks like things run in sync more or less).

After a lot of digging in and checking things out this change seems to fix that. Now it's basically very similar to local dev setup - we have a single (gunicorn worker) process which runs stuff in async because of the eventlet monkey patching.

TODO:
- [ ] st2 changes (eventlet monkey patch in gunicorn config)
- [ ] Same changes for new packages (after we do more testing and verification on those changes)
- [ ] Verify how it affects stream endpoint - async worker is actually more appropriate for stream endpoint (long running requests), but we don't have much choice right now since performance with sync workers sucks.
